### PR TITLE
GeckoLib Animation Utils 2.0.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -202,11 +202,12 @@
     "min_version": "3.2.0"
   },
   "animation_utils": {
-    "title": "Gecko's Animation Utils",
-    "author": "Gecko",
+    "title": "GeckoLib Animation Utils",
+    "author": "Eliot Lash, Gecko",
     "icon": "movie_filter",
-    "description": "This plugin lets you create animated java entities with GeckoLib. Learn about Geckolib here: https://github.com/bernie-g/geckolib",
-    "version": "1.0.0",
+    "description": "This plugin lets you create animated java entities with GeckoLib. Learn about GeckoLib here: https://github.com/bernie-g/geckolib",
+    "version": "2.0.0",
+    "min_version": "3.6",
     "variant": "both"
   },
   "multi-layer": {

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -443,9 +443,9 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			Keyframe.prototype.getArray = keyframeGetArray;
 			Keyframe.prototype.getUndoCopy = keyframeGetUndoCopy;
 			Keyframe.prototype.extend = keyframeExtend;
-			Keyframe = patch(Keyframe, "KeyframeOriginal", {
-				constructed: keyframeConstructor,
-			});
+			// Keyframe = patch(Keyframe, "KeyframeOriginal", {
+			// 	constructed: keyframeConstructor,
+			// });
 			
 			global.updateKeyframeEasing = updateKeyframeEasing;
 			
@@ -499,7 +499,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			exportAction.delete();
 			button.delete();
 			delete global.updateKeyframeEasing;
-	 		Keyframe = KeyframeOriginal;
+	 		// Keyframe = KeyframeOriginal;
 			Keyframe.prototype.getLerp = KeyframeGetLerpOriginal;
 			Keyframe.prototype.getArray = KeyframeGetArrayOriginal;
 			Keyframe.prototype.getUndoCopy = KeyframeGetUndoCopyOriginal;

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -10,49 +10,6 @@
 		return Math.floor(num);
 	}
 
-	// For monkeypatching constructors from https://github.com/jamesallardice/patchwork.js
-	const patch = (function () {
-    /*jshint evil: true */
-
-    "use strict";
-
-    var global = new Function("return this;")(), // Get a reference to the global object
-        fnProps = Object.getOwnPropertyNames(Function); // Get the own ("static") properties of the Function constructor
-
-    return function (original, originalRef, patches) {
-
-        var ref = global[originalRef] = original, // Maintain a reference to the original constructor as a new property on the global object
-            args = [],
-            newRef, // This will be the new patched constructor
-            i;
-
-        patches.called = patches.called || originalRef; // If we are not patching static calls just pass them through to the original function
-
-        for (i = 0; i < original.length; i++) { // Match the arity of the original constructor
-            args[i] = "a" + i; // Give the arguments a name (native constructors don't care, but user-defined ones will break otherwise)
-        }
-
-        if (patches.constructed) { // This string is evaluated to create the patched constructor body in the case that we are patching newed calls
-            args.push("'use strict'; return (!!this ? " + patches.constructed + " : " + patches.called + ").apply(null, arguments);"); 
-        } else { // This string is evaluated to create the patched constructor body in the case that we are only patching static calls
-            args.push("'use strict'; return (!!this ? new (Function.prototype.bind.apply(" + originalRef + ", [{}].concat([].slice.call(arguments))))() : " + patches.called + ".apply(null, arguments));");
-        }
-
-        newRef = new (Function.prototype.bind.apply(Function, [{}].concat(args)))(); // Create a new function to wrap the patched constructor
-        newRef.prototype = original.prototype; // Keep a reference to the original prototype to ensure instances of the patch appear as instances of the original
-        newRef.prototype.constructor = newRef; // Ensure the constructor of patched instances is the patched constructor
-
-        Object.getOwnPropertyNames(ref).forEach(function (property) { // Add any "static" properties of the original constructor to the patched one
-            if (fnProps.indexOf(property) < 0) { // Don't include static properties of Function since the patched constructor will already have them
-                newRef[property] = ref[property];
-            }
-        });
-
-        return newRef; // Return the patched constructor
-    };
-
-}());
-
 function lerp(start, stop, amt) {
   return amt * (stop - start) + start;
 };
@@ -325,10 +282,6 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 					// 	return n;
 					// }
 					const keyframe = document.getElementById('keyframe');
-					// console.log(`updateKeyframeSelection:`, args, ' keyframe:', keyframe);
-					// const easingBar = $(`<div class="bar flex" id="keyframe_bar_easing">
-					// 	<label class="tl" style="font-weight: bolder; min-width: 47px;">Easing</label>
-					// </div>`);
 					let easingBar = document.createElement('div');
 					keyframe.appendChild(easingBar);
 					easingBar.outerHTML = `<div class="bar flex" id="keyframe_bar_easing">
@@ -336,9 +289,6 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 					</div>`;
 					easingBar = document.getElementById('keyframe_bar_easing');
 
-					// var el = $(`<div class="bar_select half"><select class="focusable_input" id="${form_id}"></select></div>`)
-					// const el = $(`<select class="focusable_input" id="keyframe_easing" style="flex: 1; margin-right: 9px;"></select>`)
-					// const sel = el.find('select')
 					let sel = document.createElement('select');
 					easingBar.appendChild(sel);
 					sel.outerHTML = `<select class="focusable_input" id="keyframe_easing" style="flex: 1; margin-right: 9px;" oninput="updateKeyframeEasing(this)"></select>`;
@@ -347,26 +297,14 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 						var name = EASING_OPTIONS[key];
 						const option = document.createElement('option')
 						sel.appendChild(option);
-						// option.outerHTML = `<option id="${key}" ${first.easing || EASING_DEFAULT === key ? 'selected' : ''}>${name}</option>`;
 						option.outerHTML = `<option id="${key}" ${(first.easing || EASING_DEFAULT) === key ? 'selected' : ''}>${name}</option>`;
 					}
-					// easingBar.append(el)
-						// <input type="text" id="keyframe_easing" axis="easing" class="dark_bordered code keyframe_input tab_target" style="flex: 1; margin-right: 9px;" oninput="updateKeyframeEasing(this)"></input>
 					console.log('easingBar:', easingBar, 'keyframe:', keyframe);
-					// $('#keyframe_bar_easing input').val(first.easing || '');
 			}
 		}
 	};
 
 	const KeyframeGetLerpOriginal = Keyframe.prototype.getLerp;
-	// getLerp(other, axis, amount, allow_expression) {
-	// 	if (allow_expression && this.get(axis) === other.get(axis)) {
-	// 		return this.get(axis)
-	// 	} else {
-	// 		let calc = this.calc(axis)
-	// 		return calc + (other.calc(axis) - calc) * amount
-	// 	}
-	// }
 	function keyframeGetLerp(other, axis, amount, allow_expression) {
 			const easing = this.easing || EASING_DEFAULT;
 			if (Format.id !== "animated_entity_model") {
@@ -417,14 +355,6 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		return result;
 	}
 
-	function keyframeConstructor(data, uuid) {
-			// const result = new (Function.prototype.bind.apply(KeyframeOriginal, arguments));//[{}].concat(arguments)));
-			const result = new (Function.prototype.bind.apply(KeyframeOriginal, [{}, ...arguments]));
-			// if (Format.id === "animated_entity_model") Object.assign(result, { easing: data.easing });
-			// console.log('keyframeConstructor arguments:', arguments, 'this:', this, 'result:', result);
-			return result;
-	}
-
 	Plugin.register("animation_utils", {
 		name: "Gecko's Animation Utils",
 		author: "Gecko",
@@ -443,9 +373,6 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			Keyframe.prototype.getArray = keyframeGetArray;
 			Keyframe.prototype.getUndoCopy = keyframeGetUndoCopy;
 			Keyframe.prototype.extend = keyframeExtend;
-			// Keyframe = patch(Keyframe, "KeyframeOriginal", {
-			// 	constructed: keyframeConstructor,
-			// });
 			
 			global.updateKeyframeEasing = updateKeyframeEasing;
 			
@@ -499,7 +426,6 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			exportAction.delete();
 			button.delete();
 			delete global.updateKeyframeEasing;
-	 		// Keyframe = KeyframeOriginal;
 			Keyframe.prototype.getLerp = KeyframeGetLerpOriginal;
 			Keyframe.prototype.getArray = KeyframeGetArrayOriginal;
 			Keyframe.prototype.getUndoCopy = KeyframeGetUndoCopyOriginal;

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -521,6 +521,9 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 							case EASING_OPTIONS.easeInElastic:
 							case EASING_OPTIONS.easeOutElastic:
 							case EASING_OPTIONS.easeInOutElastic:
+							case EASING_OPTIONS.easeInBounce:
+							case EASING_OPTIONS.easeOutBounce:
+							case EASING_OPTIONS.easeInOutBounce:
 								return 'Bounciness';
 							case EASING_OPTIONS.step:
 								return 'Steps';
@@ -636,13 +639,19 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 		return result;
 	}
 
+	function reverseKeyframesCondition() {
+		const res = Original.get(BarItems.reverse_keyframes).condition() && Format.id !== "animated_entity_model";
+		console.log('reverseKeyframesCondition original:',Original.get(BarItems.reverse_keyframes).condition(), 'res:', res);
+		return res;
+	}
+
 	//#endregion Keyframe Mixins
 
 	//#region Plugin Definition
 	const PLUGIN_VERSION = "2.0.0";
 	const MIN_BLOCKBENCH_VERSION = "3.6";
-  let holdMenu;
-  let holdMenuConditionOriginal;
+	let holdMenu;
+	let holdMenuConditionOriginal;
 
 	Plugin.register("animation_utils", {
 		name: "GeckoLib Animation Utils",
@@ -652,7 +661,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			`This plugin lets you create animated java entities with GeckoLib. This plugin requires Blockbench ${MIN_BLOCKBENCH_VERSION} or higher. Learn about GeckoLib here: https://github.com/bernie-g/geckolib`,
 		icon: "movie_filter",
 		version: PLUGIN_VERSION,
-    min_version: MIN_BLOCKBENCH_VERSION,
+		min_version: MIN_BLOCKBENCH_VERSION,
 		variant: "both",
 		onload() {
 			Codecs.project.on('compile', compileCallback);
@@ -664,14 +673,16 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			addMonkeypatch(Keyframe, "prototype", "getArray", keyframeGetArray);
 			addMonkeypatch(Keyframe, "prototype", "getUndoCopy", keyframeGetUndoCopy);
 			addMonkeypatch(Keyframe, "prototype", "extend", keyframeExtend);
+
+			addMonkeypatch(BarItems.reverse_keyframes, null, "condition", reverseKeyframesCondition);
 			
 			addMonkeypatch(global, null, "updateKeyframeEasing", updateKeyframeEasing);
 			addMonkeypatch(global, null, "updateKeyframeEasingArg", updateKeyframeEasingArg);
 
-      holdMenu = Animation.prototype.menu.structure.find(x => x.name === 'menu.animation.loop')
-        .children.find(x => x.name === 'menu.animation.loop.hold');
-      holdMenuConditionOriginal = holdMenu.condition;
-      holdMenu.condition = () => Format.id !== "animated_entity_model";
+			holdMenu = Animation.prototype.menu.structure.find(x => x.name === 'menu.animation.loop')
+				.children.find(x => x.name === 'menu.animation.loop.hold');
+			holdMenuConditionOriginal = holdMenu.condition;
+			holdMenu.condition = () => Format.id !== "animated_entity_model";
 
 			exportAction = new Action({
 				id: "export_animated_entity_model",
@@ -723,7 +734,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			exportAction.delete();
 			button.delete();
 			removeMonkeypatches();
-      holdMenu.condition = holdMenuConditionOriginal;
+			holdMenu.condition = holdMenuConditionOriginal;
 			console.clear();
 		},
 	});

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -641,6 +641,8 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 	//#region Plugin Definition
 	const PLUGIN_VERSION = "2.0.0";
 	const MIN_BLOCKBENCH_VERSION = "3.6";
+  let holdMenu;
+  let holdMenuConditionOriginal;
 
 	Plugin.register("animation_utils", {
 		name: "GeckoLib Animation Utils",
@@ -665,6 +667,11 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			
 			addMonkeypatch(global, null, "updateKeyframeEasing", updateKeyframeEasing);
 			addMonkeypatch(global, null, "updateKeyframeEasingArg", updateKeyframeEasingArg);
+
+      holdMenu = Animation.prototype.menu.structure.find(x => x.name === 'menu.animation.loop')
+        .children.find(x => x.name !== 'menu.animation.loop.hold');
+      holdMenuConditionOriginal = holdMenu.condition;
+      holdMenu.condition = () => Format.id !== "animated_entity_model";
 
 			exportAction = new Action({
 				id: "export_animated_entity_model",
@@ -716,6 +723,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			exportAction.delete();
 			button.delete();
 			removeMonkeypatches();
+      holdMenu.condition = holdMenuConditionOriginal;
 			console.clear();
 		},
 	});

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -321,8 +321,23 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 				}
 			};
 
+			const keyframesByChannel = Timeline.keyframes.reduce((acc, kf) => {
+				if (!acc.has(kf.animator)) acc.set(kf.animator, {});
+				const animatorChannels = acc.get(kf.animator);
+				if (!animatorChannels[kf.channel]) animatorChannels[kf.channel] = [];
+				animatorChannels[kf.channel].push(kf);
+				animatorChannels[kf.channel].sort((a, b) => {
+					if (a.time < b.time) return -1;
+					if (a.time > b.time) return 1;
+					return 0;
+				});
+				return acc;
+			}, new Map());
+
+			const isFirstInChannel = kf => keyframesByChannel.get(kf.animator)[kf.channel].indexOf(kf) < 1;
+
 			if (Timeline.selected.length && Format.id === "animated_entity_model") {
-				if (Timeline.selected.every(kf => kf.animator instanceof BoneAnimator)) {
+				if (Timeline.selected.every(kf => kf.animator instanceof BoneAnimator && !isFirstInChannel(kf))) {
 					const displayedEasing = getMultiSelectValue('easing', EASING_DEFAULT, 'null');
 
 					const keyframe = document.getElementById('keyframe');

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -1,4 +1,5 @@
 (function () {
+	//#region Helper Functions
 	function F(num) {
 		var s = trimFloatNumber(num) + "";
 		if (!s.includes(".")) {
@@ -10,178 +11,175 @@
 		return Math.floor(num);
 	}
 
-function lerp(start, stop, amt) {
-  return amt * (stop - start) + start;
-};
-
-function uniq(arr) {
-	return arr.reduce((acc, val) => {
-		if (!acc.includes(val)) {
-			return [...acc, val];
-		}
-		return acc;
-	}, []);
-}
-
-const easingsFunctions = (function() {
-	const pow = Math.pow;
-	const sqrt = Math.sqrt;
-	const sin = Math.sin;
-	const cos = Math.cos;
-	const PI = Math.PI;
-	const getC1 = scalar => 1.70158 * scalar;
-  const getC2 = c1 => c1 * 1.525;
-	const getC3 = c1 => c1 + 1;
-	const c4 = (2 * PI) / 3;
-	const c5 = (2 * PI) / 4.5;
-	function bounceOut(x) {
-			const n1 = 7.5625;
-			const d1 = 2.75;
-			if (x < 1 / d1) {
-					return n1 * x * x;
-			}
-			else if (x < 2 / d1) {
-					return n1 * (x -= 1.5 / d1) * x + 0.75;
-			}
-			else if (x < 2.5 / d1) {
-					return n1 * (x -= 2.25 / d1) * x + 0.9375;
-			}
-			else {
-					return n1 * (x -= 2.625 / d1) * x + 0.984375;
-			}
-	}
-	const easingsFunctions = {
-			linear(x) {
-				return x;
-			},
-			easeInQuad(x) {
-					return x * x;
-			},
-			easeOutQuad(x) {
-					return 1 - (1 - x) * (1 - x);
-			},
-			easeInOutQuad(x) {
-					return x < 0.5 ? 2 * x * x : 1 - pow(-2 * x + 2, 2) / 2;
-			},
-			easeInCubic(x) {
-					return x * x * x;
-			},
-			easeOutCubic(x) {
-					return 1 - pow(1 - x, 3);
-			},
-			easeInOutCubic(x) {
-					return x < 0.5 ? 4 * x * x * x : 1 - pow(-2 * x + 2, 3) / 2;
-			},
-			easeInQuart(x) {
-					return x * x * x * x;
-			},
-			easeOutQuart(x) {
-					return 1 - pow(1 - x, 4);
-			},
-			easeInOutQuart(x) {
-					return x < 0.5 ? 8 * x * x * x * x : 1 - pow(-2 * x + 2, 4) / 2;
-			},
-			easeInQuint(x) {
-					return x * x * x * x * x;
-			},
-			easeOutQuint(x) {
-					return 1 - pow(1 - x, 5);
-			},
-			easeInOutQuint(x) {
-					return x < 0.5 ? 16 * x * x * x * x * x : 1 - pow(-2 * x + 2, 5) / 2;
-			},
-			easeInSine(x) {
-					return 1 - cos((x * PI) / 2);
-			},
-			easeOutSine(x) {
-					return sin((x * PI) / 2);
-			},
-			easeInOutSine(x) {
-					return -(cos(PI * x) - 1) / 2;
-			},
-			easeInExpo(x) {
-					return x === 0 ? 0 : pow(2, 10 * x - 10);
-			},
-			easeOutExpo(x) {
-					return x === 1 ? 1 : 1 - pow(2, -10 * x);
-			},
-			easeInOutExpo(x) {
-					return x === 0
-							? 0
-							: x === 1
-									? 1
-									: x < 0.5
-											? pow(2, 20 * x - 10) / 2
-											: (2 - pow(2, -20 * x + 10)) / 2;
-			},
-			easeInCirc(x) {
-					return 1 - sqrt(1 - pow(x, 2));
-			},
-			easeOutCirc(x) {
-					return sqrt(1 - pow(x - 1, 2));
-			},
-			easeInOutCirc(x) {
-					return x < 0.5
-							? (1 - sqrt(1 - pow(2 * x, 2))) / 2
-							: (sqrt(1 - pow(-2 * x + 2, 2)) + 1) / 2;
-			},
-			easeInBack(scalar, x) {
-				const c1 = getC1(scalar);
-				const c3 = getC3(c1);
-				return c3 * x * x * x - c1 * x * x;
-			},
-			easeOutBack(scalar, x) {
-				const c1 = getC1(scalar);
-				const c3 = getC3(c1);
-				return 1 + c3 * pow(x - 1, 3) + c1 * pow(x - 1, 2);
-			},
-			easeInOutBack(scalar, x) {
-					const c1 = getC1(scalar);
-					const c2 = getC2(c1);
-					return x < 0.5
-							? (pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
-							: (pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
-			},
-			easeInElastic(x) {
-					return x === 0
-							? 0
-							: x === 1
-									? 1
-									: -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
-			},
-			easeOutElastic(x) {
-					return x === 0
-							? 0
-							: x === 1
-									? 1
-									: pow(2, -10 * x) * sin((x * 10 - 0.75) * c4) + 1;
-			},
-			easeInOutElastic(x) {
-					return x === 0
-							? 0
-							: x === 1
-									? 1
-									: x < 0.5
-											? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
-											: (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
-			},
-			easeInBounce(x) {
-					return 1 - bounceOut(1 - x);
-			},
-			easeOutBounce: bounceOut,
-			easeInOutBounce(x) {
-					return x < 0.5
-							? (1 - bounceOut(1 - 2 * x)) / 2
-							: (1 + bounceOut(2 * x - 1)) / 2;
-			},
+	function lerp(start, stop, amt) {
+		return amt * (stop - start) + start;
 	};
-	return easingsFunctions;
-})();
 
-	// const MOD_SDK_1_15_FORGE = '1.15 - Forge';
-	// const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
-	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
-	// const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
+	function uniq(arr) {
+		return arr.reduce((acc, val) => {
+			if (!acc.includes(val)) {
+				return [...acc, val];
+			}
+			return acc;
+		}, []);
+	}
+	//#endregion Helper Functions
+
+	//#region Easing Functions
+	const easingsFunctions = (function() {
+		const pow = Math.pow;
+		const sqrt = Math.sqrt;
+		const sin = Math.sin;
+		const cos = Math.cos;
+		const PI = Math.PI;
+		const getC1 = scalar => 1.70158 * scalar;
+		const getC2 = c1 => c1 * 1.525;
+		const getC3 = c1 => c1 + 1;
+		const c4 = (2 * PI) / 3;
+		const c5 = (2 * PI) / 4.5;
+		function bounceOut(x) {
+				const n1 = 7.5625;
+				const d1 = 2.75;
+				if (x < 1 / d1) {
+						return n1 * x * x;
+				}
+				else if (x < 2 / d1) {
+						return n1 * (x -= 1.5 / d1) * x + 0.75;
+				}
+				else if (x < 2.5 / d1) {
+						return n1 * (x -= 2.25 / d1) * x + 0.9375;
+				}
+				else {
+						return n1 * (x -= 2.625 / d1) * x + 0.984375;
+				}
+		}
+		const easingsFunctions = {
+				linear(x) {
+					return x;
+				},
+				easeInQuad(x) {
+						return x * x;
+				},
+				easeOutQuad(x) {
+						return 1 - (1 - x) * (1 - x);
+				},
+				easeInOutQuad(x) {
+						return x < 0.5 ? 2 * x * x : 1 - pow(-2 * x + 2, 2) / 2;
+				},
+				easeInCubic(x) {
+						return x * x * x;
+				},
+				easeOutCubic(x) {
+						return 1 - pow(1 - x, 3);
+				},
+				easeInOutCubic(x) {
+						return x < 0.5 ? 4 * x * x * x : 1 - pow(-2 * x + 2, 3) / 2;
+				},
+				easeInQuart(x) {
+						return x * x * x * x;
+				},
+				easeOutQuart(x) {
+						return 1 - pow(1 - x, 4);
+				},
+				easeInOutQuart(x) {
+						return x < 0.5 ? 8 * x * x * x * x : 1 - pow(-2 * x + 2, 4) / 2;
+				},
+				easeInQuint(x) {
+						return x * x * x * x * x;
+				},
+				easeOutQuint(x) {
+						return 1 - pow(1 - x, 5);
+				},
+				easeInOutQuint(x) {
+						return x < 0.5 ? 16 * x * x * x * x * x : 1 - pow(-2 * x + 2, 5) / 2;
+				},
+				easeInSine(x) {
+						return 1 - cos((x * PI) / 2);
+				},
+				easeOutSine(x) {
+						return sin((x * PI) / 2);
+				},
+				easeInOutSine(x) {
+						return -(cos(PI * x) - 1) / 2;
+				},
+				easeInExpo(x) {
+						return x === 0 ? 0 : pow(2, 10 * x - 10);
+				},
+				easeOutExpo(x) {
+						return x === 1 ? 1 : 1 - pow(2, -10 * x);
+				},
+				easeInOutExpo(x) {
+						return x === 0
+								? 0
+								: x === 1
+										? 1
+										: x < 0.5
+												? pow(2, 20 * x - 10) / 2
+												: (2 - pow(2, -20 * x + 10)) / 2;
+				},
+				easeInCirc(x) {
+						return 1 - sqrt(1 - pow(x, 2));
+				},
+				easeOutCirc(x) {
+						return sqrt(1 - pow(x - 1, 2));
+				},
+				easeInOutCirc(x) {
+						return x < 0.5
+								? (1 - sqrt(1 - pow(2 * x, 2))) / 2
+								: (sqrt(1 - pow(-2 * x + 2, 2)) + 1) / 2;
+				},
+				easeInBack(scalar, x) {
+					const c1 = getC1(scalar);
+					const c3 = getC3(c1);
+					return c3 * x * x * x - c1 * x * x;
+				},
+				easeOutBack(scalar, x) {
+					const c1 = getC1(scalar);
+					const c3 = getC3(c1);
+					return 1 + c3 * pow(x - 1, 3) + c1 * pow(x - 1, 2);
+				},
+				easeInOutBack(scalar, x) {
+						const c1 = getC1(scalar);
+						const c2 = getC2(c1);
+						return x < 0.5
+								? (pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
+								: (pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
+				},
+				easeInElastic(x) {
+						return x === 0
+								? 0
+								: x === 1
+										? 1
+										: -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
+				},
+				easeOutElastic(x) {
+						return x === 0
+								? 0
+								: x === 1
+										? 1
+										: pow(2, -10 * x) * sin((x * 10 - 0.75) * c4) + 1;
+				},
+				easeInOutElastic(x) {
+						return x === 0
+								? 0
+								: x === 1
+										? 1
+										: x < 0.5
+												? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
+												: (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
+				},
+				easeInBounce(x) {
+						return 1 - bounceOut(1 - x);
+				},
+				easeOutBounce: bounceOut,
+				easeInOutBounce(x) {
+						return x < 0.5
+								? (1 - bounceOut(1 - 2 * x)) / 2
+								: (1 + bounceOut(2 * x - 1)) / 2;
+				},
+		};
+		return easingsFunctions;
+	})();
 
 	const EASING_OPTIONS = {
 		linear: "linear",
@@ -219,16 +217,24 @@ const easingsFunctions = (function() {
 	Object.freeze(EASING_OPTIONS);
 	const EASING_DEFAULT = 'linear';
 
-	const geckoSettingsDefault = {
+	//#endregion Easing Functions
+
+	//#region Codec Helpers / Export Settings
+	const GECKO_SETTINGS_DEFAULT = {
 		// modSDK: MOD_SDK_1_15_FORGE,
 		entityType: 'Entity',
 		javaPackage: 'com.example.mod',
 		animFileNamespace: 'MODID',
 		animFilePath: 'animations/ANIMATIONFILE.json',
 	};
-	Object.freeze(geckoSettingsDefault);
+	Object.freeze(GECKO_SETTINGS_DEFAULT);
 
-	let geckoSettings = Object.assign({}, geckoSettingsDefault);
+	let geckoSettings = Object.assign({}, GECKO_SETTINGS_DEFAULT);
+
+	// const MOD_SDK_1_15_FORGE = '1.15 - Forge';
+	// const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
+	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
+	// const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
 
 	const getImports = () => {
 		// switch(geckoSettings.modSDK) {
@@ -254,10 +260,13 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		if (e.model && typeof e.model.geckoSettings === 'object') {
 			geckoSettings = e.model.geckoSettings;
 		} else {
-			geckoSettings = Object.assign({}, geckoSettingsDefault);
+			geckoSettings = Object.assign({}, GECKO_SETTINGS_DEFAULT);
 		}
 	};
 
+	//#endregion Codec Helpers / Export Settings
+
+	//#region Global Animation UI Handlers
 	const displayAnimationFrameCallback = (...args) => {
 		// const keyframe = $('#keyframe');
 		// console.log('displayAnimationFrameCallback:', args, 'keyframe:', keyframe); // keyframe is null here
@@ -353,6 +362,9 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		}
 	};
 
+	//#endregion Global Animation UI Handlers
+
+	//#region Keyframe Mixins
 	const KeyframeGetLerpOriginal = Keyframe.prototype.getLerp;
 	function keyframeGetLerp(other, axis, amount, allow_expression) {
 			const easing = this.easing || EASING_DEFAULT;
@@ -417,6 +429,9 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		return result;
 	}
 
+	//#endregion Keyframe Mixins
+
+	//#region Plugin Definition
 	Plugin.register("animation_utils", {
 		name: "Gecko's Animation Utils",
 		author: "Gecko",
@@ -497,7 +512,9 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			console.clear();
 		},
 	});
+	//#endregion Plugin Definition
 
+	//#region Codec / ModelFormat
 	const Templates = {
 		"1.15": {
 			name: "1.15",
@@ -1155,4 +1172,6 @@ this.registerModelRenderer(%(bone));`,
 	});
 	//Object.defineProperty(format, 'integer_size', {get: _ => Templates.get('integer_size')})
 	codec.format = format;
+
+	//#endregion Codec / ModelFormat
 })();

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -640,15 +640,17 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 
 	//#region Plugin Definition
 	const PLUGIN_VERSION = "2.0.0";
+	const MIN_BLOCKBENCH_VERSION = "3.6";
 
 	Plugin.register("animation_utils", {
 		name: "GeckoLib Animation Utils",
 		author: "Eliot Lash, Gecko",
 		title: "GeckoLib Animation Utils",
 		description:
-			"This plugin lets you create animated java entities with GeckoLib. This plugin requires Blockbench 3.5.4 or higher. Learn about GeckoLib here: https://github.com/bernie-g/geckolib",
+			`This plugin lets you create animated java entities with GeckoLib. This plugin requires Blockbench ${MIN_BLOCKBENCH_VERSION} or higher. Learn about GeckoLib here: https://github.com/bernie-g/geckolib`,
 		icon: "movie_filter",
 		version: PLUGIN_VERSION,
+    min_version: MIN_BLOCKBENCH_VERSION,
 		variant: "both",
 		onload() {
 			Codecs.project.on('compile', compileCallback);

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -58,6 +58,42 @@
 	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
 	// const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
 
+	const EASING_OPTIONS = {
+		linear: "linear",
+		easeInSine: "easeInSine",
+		easeOutSine: "easeOutSine",
+		easeInOutSine: "easeInOutSine",
+		easeInQuad: "easeInQuad",
+		easeOutQuad: "easeOutQuad",
+		easeInOutQuad: "easeInOutQuad",
+		easeInCubic: "easeInCubic",
+		easeOutCubic: "easeOutCubic",
+		easeInOutCubic: "easeInOutCubic",
+		easeInQuart: "easeInQuart",
+		easeOutQuart: "easeOutQuart",
+		easeInOutQuart: "easeInOutQuart",
+		easeInQuint: "easeInQuint",
+		easeOutQuint: "easeOutQuint",
+		easeInOutQuint: "easeInOutQuint",
+		easeInExpo: "easeInExpo",
+		easeOutExpo: "easeOutExpo",
+		easeInOutExpo: "easeInOutExpo",
+		easeInCirc: "easeInCirc",
+		easeOutCirc: "easeOutCirc",
+		easeInOutCirc: "easeInOutCirc",
+		easeInBack: "easeInBack",
+		easeOutBack: "easeOutBack",
+		easeInOutBack: "easeInOutBack",
+		easeInElastic: "easeInElastic",
+		easeOutElastic: "easeOutElastic",
+		easeInOutElastic: "easeInOutElastic",
+		easeInBounce: "easeInBounce",
+		easeOutBounce: "easeOutBounce",
+		easeInOutBounce: "easeInOutBounce",
+	};
+	Object.freeze(EASING_OPTIONS);
+	const EASING_DEFAULT = 'linear';
+
 	const geckoSettingsDefault = {
 		// modSDK: MOD_SDK_1_15_FORGE,
 		entityType: 'Entity',
@@ -104,12 +140,13 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 
 	function updateKeyframeEasing(obj) {
 		console.log('updateKeyframeEasing:', obj); 
-		var axis = $(obj).attr('axis');
+		// var axis = $(obj).attr('axis');
 		var value = $(obj).val();
 		Timeline.selected.forEach(function(kf) {
-			kf.set(axis, value);
+			// kf.set(axis, value);
+			kf.easing = value;
 		})
-		Animator.preview();
+		// Animator.preview();
 	}
 
 	const updateKeyframeSelectionCallback = (...args) => {
@@ -134,13 +171,36 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 					// 	if (typeof n == 'number') return trimFloatNumber(n);
 					// 	return n;
 					// }
-					const keyframe = $('#keyframe');
+					const keyframe = document.getElementById('keyframe');
 					// console.log(`updateKeyframeSelection:`, args, ' keyframe:', keyframe);
-					keyframe.append(`<div class="bar flex" id="keyframe_bar_easing">
+					// const easingBar = $(`<div class="bar flex" id="keyframe_bar_easing">
+					// 	<label class="tl" style="font-weight: bolder; min-width: 47px;">Easing</label>
+					// </div>`);
+					let easingBar = document.createElement('div');
+					keyframe.appendChild(easingBar);
+					easingBar.outerHTML = `<div class="bar flex" id="keyframe_bar_easing">
 						<label class="tl" style="font-weight: bolder; min-width: 47px;">Easing</label>
-						<input type="text" id="keyframe_easing" axis="easing" class="dark_bordered code keyframe_input tab_target" style="flex: 1; margin-right: 9px;" oninput="updateKeyframeEasing(this)">
-					</div>`);
-					$('#keyframe_bar_easing input').val(first.easing || '');
+					</div>`;
+					easingBar = document.getElementById('keyframe_bar_easing');
+
+					// var el = $(`<div class="bar_select half"><select class="focusable_input" id="${form_id}"></select></div>`)
+					// const el = $(`<select class="focusable_input" id="keyframe_easing" style="flex: 1; margin-right: 9px;"></select>`)
+					// const sel = el.find('select')
+					let sel = document.createElement('select');
+					easingBar.appendChild(sel);
+					sel.outerHTML = `<select class="focusable_input" id="keyframe_easing" style="flex: 1; margin-right: 9px;" oninput="updateKeyframeEasing(this)"></select>`;
+					sel = document.getElementById('keyframe_easing');
+					for (var key in EASING_OPTIONS) {
+						var name = EASING_OPTIONS[key];
+						const option = document.createElement('option')
+						sel.appendChild(option);
+						// option.outerHTML = `<option id="${key}" ${first.easing || EASING_DEFAULT === key ? 'selected' : ''}>${name}</option>`;
+						option.outerHTML = `<option id="${key}" ${(first.easing || EASING_DEFAULT) === key ? 'selected' : ''}>${name}</option>`;
+					}
+					// easingBar.append(el)
+						// <input type="text" id="keyframe_easing" axis="easing" class="dark_bordered code keyframe_input tab_target" style="flex: 1; margin-right: 9px;" oninput="updateKeyframeEasing(this)"></input>
+					console.log('easingBar:', easingBar, 'keyframe:', keyframe);
+					// $('#keyframe_bar_easing input').val(first.easing || '');
 			}
 		}
 	};

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -10,15 +10,15 @@
 		return Math.floor(num);
 	}
 
-	const MOD_SDK_1_15_FORGE = '1.15 - Forge';
-	const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
-	const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
-	const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
+	// const MOD_SDK_1_15_FORGE = '1.15 - Forge';
+	// const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
+	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
+	// const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
 
 	const geckoSettingsDefault = {
 		// modSDK: MOD_SDK_1_15_FORGE,
 		entityType: 'Entity',
-		javaPackage: 'package com.example.mod;',
+		javaPackage: 'com.example.mod',
 		animFileNamespace: 'MODID',
 		animFilePath: 'animations/ANIMATIONFILE.json',
 	};
@@ -126,7 +126,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 // Exported for Minecraft version 1.12.2 or 1.15.2 (same format for both) for entity models animated with GeckoLib
 // Paste this class into your mod and follow the documentation for GeckoLib to use animations. You can find the documentation here: https://github.com/bernie-g/geckolib
 // Blockbench plugin created by Gecko
-%(javaPackage)
+package %(javaPackage);
 
 %(imports)
 

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -395,7 +395,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 	};
 
 	const parseCallback = (e) => {
-		console.log(`parseCallback:`, e);
+		// console.log(`parseCallback:`, e);
 		if (e.model && typeof e.model.geckoSettings === 'object') {
 			Object.assign(geckoSettings, e.model.geckoSettings);
 		} else {
@@ -420,7 +420,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 	function updateKeyframeEasing(obj) {
 		// var axis = $(obj).attr('axis');
 		const value = $(obj).val();
-		console.log('updateKeyframeEasing value:', value, 'obj:', obj); 
+		// console.log('updateKeyframeEasing value:', value, 'obj:', obj); 
 		if (value === "-") return;
 		Timeline.selected.forEach((kf) => {
 			kf.easing = value;
@@ -431,7 +431,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 
 	function updateKeyframeEasingArg(obj) {
 		if ($(obj).val() === "-") return;
-		console.log('updateKeyframeEasingArg value:', $(obj).val(), 'obj:', obj); 
+		// console.log('updateKeyframeEasingArg value:', $(obj).val(), 'obj:', obj); 
 		Timeline.selected.forEach((kf) => {
 			const value = parseEasingArg(kf, $(obj).val().trim());
 			kf.easingArgs = [value];
@@ -544,7 +544,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 						scaleBar = document.getElementById('keyframe_bar_easing_arg1');
 					}
 
-					console.log('easingBar:', easingBar, 'keyframe:', keyframe);
+					// console.log('easingBar:', easingBar, 'keyframe:', keyframe);
 			}
 		}
 	};
@@ -578,14 +578,14 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 				const arg1 = Array.isArray(other.easingArgs) && other.easingArgs.length > 0
 					? other.easingArgs[0]
 					: getEasingArgDefault(other);
-				console.log(`keyframeGetLerp arg1: ${arg1}`);
+				// console.log(`keyframeGetLerp arg1: ${arg1}`);
 				easingFunc = easingFunc.bind(null, arg1);
 			}
 			const easedAmount = easingFunc(amount); 
 			const start = this.calc(axis);
 			const stop = other.calc(axis);
 			const result = lerp(start, stop, easedAmount);
-			console.log('keyframeGetLerp easing:', easing, 'arguments:', arguments, 'start:', start, 'stop:', stop, 'amount:', amount, 'easedAmount:', easedAmount, 'result:', result);
+			// console.log('keyframeGetLerp easing:', easing, 'arguments:', arguments, 'start:', start, 'stop:', stop, 'amount:', amount, 'easedAmount:', easedAmount, 'result:', result);
 			if (Number.isNaN(result)) {
 				throw new Error('batman');
 			}
@@ -599,7 +599,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 				result = { vector: result, easing };
 				if (hasArgs(easing)) result.easingArgs = easingArgs;
 			}
-			console.log('keyframeGetArray arguments:', arguments, 'this:', this, 'result:', result);
+			// console.log('keyframeGetArray arguments:', arguments, 'this:', this, 'result:', result);
 			return result;
 	}
 
@@ -610,7 +610,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 				Object.assign(result, { easing });
 				if (hasArgs(easing)) result.easingArgs = easingArgs;
 			}
-			console.log('keyframeGetUndoCopy arguments:', arguments, 'this:', this, 'result:', result);
+			// console.log('keyframeGetUndoCopy arguments:', arguments, 'this:', this, 'result:', result);
 			return result;
 	}
 
@@ -635,13 +635,13 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			}
 		}
 		const result = Original.get(Keyframe).extend.apply(this, arguments);
-		console.log('keyframeExtend arguments:', arguments, 'this:', this, 'result:', result);
+		// console.log('keyframeExtend arguments:', arguments, 'this:', this, 'result:', result);
 		return result;
 	}
 
 	function reverseKeyframesCondition() {
 		const res = Original.get(BarItems.reverse_keyframes).condition() && Format.id !== "animated_entity_model";
-		console.log('reverseKeyframesCondition original:',Original.get(BarItems.reverse_keyframes).condition(), 'res:', res);
+	  // console.log('reverseKeyframesCondition original:',Original.get(BarItems.reverse_keyframes).condition(), 'res:', res);
 		return res;
 	}
 

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -384,14 +384,14 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		Original.clear();
 	}
 	function keyframeGetLerp(other, axis, amount, allow_expression) {
-			const easing = this.easing || EASING_DEFAULT;
+			const easing = other.easing || EASING_DEFAULT;
 			if (Format.id !== "animated_entity_model") {
 				return Original.get(Keyframe).getLerp.apply(this, arguments);
 			}
 			let easingFunc = easingsFunctions[easing];
 			if (hasArgs(easing)) {
-				const easingScale = Array.isArray(this.easingArgs) && this.easingArgs.length > 0
-					? this.easingArgs[0]
+				const easingScale = Array.isArray(other.easingArgs) && other.easingArgs.length > 0
+					? other.easingArgs[0]
 					: 1;
 				console.log(`keyframeGetLerp easingScale: ${easingScale}`);
 				easingFunc = easingFunc.bind(null, easingScale);

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -54,6 +54,25 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		}
 	};
 
+	function updateKeyframeEasing(input) {
+		console.log('updateKeyframeEasing:', input); 
+	}
+
+	const displayAnimationFrameCallback = (...args) => {
+		const keyframe = $('#keyframe');
+		console.log('displayAnimationFrameCallback:', args, 'keyframe:', keyframe);
+	};
+
+	const updateKeyframeSelectionCallback = (...args) => {
+		$('#keyframe_bar_easing').remove()
+		const keyframe = $('#keyframe');
+		console.log(`updateKeyframeSelection:`, args, ' keyframe:', keyframe);
+		keyframe.append(`<div class="bar flex" id="keyframe_bar_easing">
+			<label class="tl" style="font-weight: bolder">Easing</label>
+			<input type="text" id="keyframe_easing" class="dark_bordered code keyframe_input tab_target" oninput="updateKeyframeEasing(this)">
+		</div>`);
+	};
+
 	Plugin.register("animation_utils", {
 		name: "Gecko's Animation Utils",
 		author: "Gecko",
@@ -66,6 +85,12 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		onload() {
 			Codecs.project.on('compile', compileCallback);
 			Codecs.project.on('parse', parseCallback);
+			Blockbench.on('display_animation_frame', displayAnimationFrameCallback);
+			Blockbench.on('update_keyframe_selection', updateKeyframeSelectionCallback);
+			oldUpdateKeyframeSelection = global.updateKeyframeSelection;
+			
+			global.updateKeyframeEasing = updateKeyframeEasing;
+			
 
 			exportAction = new Action({
 				id: "export_animated_entity_model",
@@ -109,10 +134,13 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			MenuBar.addAction(button, 'file.1');
 		},
 		onunload() {
-			exportAction.delete();
-			button.delete();
 			Codecs.project.events.compile.remove(compileCallback)
 			Codecs.project.events.parse.remove(parseCallback)
+			Blockbench.removeListener('display_animation_frame', displayAnimationFrameCallback);
+			Blockbench.removeListener('update_keyframe_selection', updateKeyframeSelectionCallback);
+			exportAction.delete();
+			button.delete();
+			delete global.updateKeyframeEasing;
 			console.clear();
 		},
 	});

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -384,8 +384,13 @@
 	//#endregion Easing Functions
 
 	//#region Codec Helpers / Export Settings
+	const MOD_SDK_1_15_FORGE = 'Forge 1.12 - 1.16';
+	const MOD_SDK_1_15_FABRIC = 'Fabric 1.15 - 1.16';
+	const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
+	const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
+
 	const GECKO_SETTINGS_DEFAULT = {
-		// modSDK: MOD_SDK_1_15_FORGE,
+		modSDK: MOD_SDK_1_15_FORGE,
 		entityType: 'Entity',
 		javaPackage: 'com.example.mod',
 		animFileNamespace: 'MODID',
@@ -395,23 +400,19 @@
 
 	let geckoSettings = Object.assign({}, GECKO_SETTINGS_DEFAULT);
 
-	// const MOD_SDK_1_15_FORGE = '1.15 - Forge';
-	// const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
-	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
-	// const MOD_SDK_OPTIONS = Object.fromEntries(MOD_SDKS.map(x => [x, x]));
-
 	const getImports = () => {
-		// switch(geckoSettings.modSDK) {
-		// 	case MOD_SDK_1_15_FORGE:
-		// 		return ``;
-		// 	case MOD_SDK_1_15_FABRIC:
-		// 		return ``;
-		// 	default:
-		// 		throw new Error(`Unrecognized mod SDK:`, geckoSettings.modSDK);
-		// }
-		return `import software.bernie.geckolib.animation.model.AnimatedEntityModel;
-import software.bernie.geckolib.animation.model.AnimatedModelRenderer;
-import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
+		switch(geckoSettings.modSDK) {
+			case MOD_SDK_1_15_FORGE:
+				return `import net.minecraft.util.ResourceLocation;
+import software.bernie.geckolib.animation.model.AnimatedEntityModel;
+import software.bernie.geckolib.animation.render.AnimatedModelRenderer;`;
+			case MOD_SDK_1_15_FABRIC:
+				return `import software.bernie.geckolib.forgetofabric.ResourceLocation;
+import software.bernie.geckolib.animation.model.AnimatedEntityModel;
+import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
+			default:
+				throw new Error(`Unrecognized mod SDK:`, geckoSettings.modSDK);
+		}
 	};
 
 	const compileCallback = (e) => {
@@ -422,7 +423,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 	const parseCallback = (e) => {
 		console.log(`parseCallback:`, e);
 		if (e.model && typeof e.model.geckoSettings === 'object') {
-			geckoSettings = e.model.geckoSettings;
+			Object.assign(geckoSettings, e.model.geckoSettings);
 		} else {
 			geckoSettings = Object.assign({}, GECKO_SETTINGS_DEFAULT);
 		}
@@ -663,14 +664,16 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 	//#endregion Keyframe Mixins
 
 	//#region Plugin Definition
+	const PLUGIN_VERSION = "2.0.0";
+
 	Plugin.register("animation_utils", {
-		name: "Geckolib Animation Utils",
+		name: "GeckoLib Animation Utils",
 		author: "Eliot Lash, Gecko",
-		title: "Geckolib Animation Utils",
+		title: "GeckoLib Animation Utils",
 		description:
-			"This plugin lets you create animated java entities with GeckoLib. Learn about Geckolib here: https://github.com/bernie-g/geckolib",
+			"This plugin lets you create animated java entities with GeckoLib. This plugin requires Blockbench 3.5.4 or higher. Learn about GeckoLib here: https://github.com/bernie-g/geckolib",
 		icon: "movie_filter",
-		version: "2.0.0",
+		version: PLUGIN_VERSION,
 		variant: "both",
 		onload() {
 			Codecs.project.on('compile', compileCallback);
@@ -710,8 +713,9 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 						id: 'project',
 						title: 'Animated Entity Settings',
 						width: 540,
+						lines: [`<b class="tl"><a href="https://github.com/bernie-g/geckolib">GeckoLib</a> Animation Utils v${PLUGIN_VERSION}</b>`],
 						form: {
-							// modSDK: {label: 'Modding SDK', type: 'select', default: geckoSettings.modSDK, options: MOD_SDK_OPTIONS},
+							modSDK: {label: 'Modding SDK', type: 'select', default: geckoSettings.modSDK, options: MOD_SDK_OPTIONS},
 							entityType: {label: 'Entity Type', value: geckoSettings.entityType },
 							javaPackage: {label: 'Java Package', value: geckoSettings.javaPackage},
 							animFileNamespace: {label: 'Animation File Namespace', value: geckoSettings.animFileNamespace},

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -368,7 +368,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 	// 	}
 	// }
 	function keyframeGetLerp(other, axis, amount, allow_expression) {
-			const easing = this.easing;
+			const easing = this.easing || EASING_DEFAULT;
 			if (Format.id !== "animated_entity_model") {
 				return KeyframeGetLerpOriginal.apply(this, arguments);
 			}

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -53,6 +53,159 @@
 
 }());
 
+function lerp(start, stop, amt) {
+  return amt * (stop - start) + start;
+};
+
+const easingsFunctions = (function() {
+	const pow = Math.pow;
+	const sqrt = Math.sqrt;
+	const sin = Math.sin;
+	const cos = Math.cos;
+	const PI = Math.PI;
+	const c1 = 1.70158;
+	const c2 = c1 * 1.525;
+	const c3 = c1 + 1;
+	const c4 = (2 * PI) / 3;
+	const c5 = (2 * PI) / 4.5;
+	function bounceOut(x) {
+			const n1 = 7.5625;
+			const d1 = 2.75;
+			if (x < 1 / d1) {
+					return n1 * x * x;
+			}
+			else if (x < 2 / d1) {
+					return n1 * (x -= 1.5 / d1) * x + 0.75;
+			}
+			else if (x < 2.5 / d1) {
+					return n1 * (x -= 2.25 / d1) * x + 0.9375;
+			}
+			else {
+					return n1 * (x -= 2.625 / d1) * x + 0.984375;
+			}
+	}
+	const easingsFunctions = {
+			linear(x) {
+				return x;
+			},
+			easeInQuad(x) {
+					return x * x;
+			},
+			easeOutQuad(x) {
+					return 1 - (1 - x) * (1 - x);
+			},
+			easeInOutQuad(x) {
+					return x < 0.5 ? 2 * x * x : 1 - pow(-2 * x + 2, 2) / 2;
+			},
+			easeInCubic(x) {
+					return x * x * x;
+			},
+			easeOutCubic(x) {
+					return 1 - pow(1 - x, 3);
+			},
+			easeInOutCubic(x) {
+					return x < 0.5 ? 4 * x * x * x : 1 - pow(-2 * x + 2, 3) / 2;
+			},
+			easeInQuart(x) {
+					return x * x * x * x;
+			},
+			easeOutQuart(x) {
+					return 1 - pow(1 - x, 4);
+			},
+			easeInOutQuart(x) {
+					return x < 0.5 ? 8 * x * x * x * x : 1 - pow(-2 * x + 2, 4) / 2;
+			},
+			easeInQuint(x) {
+					return x * x * x * x * x;
+			},
+			easeOutQuint(x) {
+					return 1 - pow(1 - x, 5);
+			},
+			easeInOutQuint(x) {
+					return x < 0.5 ? 16 * x * x * x * x * x : 1 - pow(-2 * x + 2, 5) / 2;
+			},
+			easeInSine(x) {
+					return 1 - cos((x * PI) / 2);
+			},
+			easeOutSine(x) {
+					return sin((x * PI) / 2);
+			},
+			easeInOutSine(x) {
+					return -(cos(PI * x) - 1) / 2;
+			},
+			easeInExpo(x) {
+					return x === 0 ? 0 : pow(2, 10 * x - 10);
+			},
+			easeOutExpo(x) {
+					return x === 1 ? 1 : 1 - pow(2, -10 * x);
+			},
+			easeInOutExpo(x) {
+					return x === 0
+							? 0
+							: x === 1
+									? 1
+									: x < 0.5
+											? pow(2, 20 * x - 10) / 2
+											: (2 - pow(2, -20 * x + 10)) / 2;
+			},
+			easeInCirc(x) {
+					return 1 - sqrt(1 - pow(x, 2));
+			},
+			easeOutCirc(x) {
+					return sqrt(1 - pow(x - 1, 2));
+			},
+			easeInOutCirc(x) {
+					return x < 0.5
+							? (1 - sqrt(1 - pow(2 * x, 2))) / 2
+							: (sqrt(1 - pow(-2 * x + 2, 2)) + 1) / 2;
+			},
+			easeInBack(x) {
+					return c3 * x * x * x - c1 * x * x;
+			},
+			easeOutBack(x) {
+					return 1 + c3 * pow(x - 1, 3) + c1 * pow(x - 1, 2);
+			},
+			easeInOutBack(x) {
+					return x < 0.5
+							? (pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
+							: (pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
+			},
+			easeInElastic(x) {
+					return x === 0
+							? 0
+							: x === 1
+									? 1
+									: -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
+			},
+			easeOutElastic(x) {
+					return x === 0
+							? 0
+							: x === 1
+									? 1
+									: pow(2, -10 * x) * sin((x * 10 - 0.75) * c4) + 1;
+			},
+			easeInOutElastic(x) {
+					return x === 0
+							? 0
+							: x === 1
+									? 1
+									: x < 0.5
+											? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
+											: (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
+			},
+			easeInBounce(x) {
+					return 1 - bounceOut(1 - x);
+			},
+			easeOutBounce: bounceOut,
+			easeInOutBounce(x) {
+					return x < 0.5
+							? (1 - bounceOut(1 - 2 * x)) / 2
+							: (1 + bounceOut(2 * x - 1)) / 2;
+			},
+	};
+	return easingsFunctions;
+})();
+
 	// const MOD_SDK_1_15_FORGE = '1.15 - Forge';
 	// const MOD_SDK_1_15_FABRIC = '1.15 - Fabric';
 	// const MOD_SDKS = [MOD_SDK_1_15_FORGE, MOD_SDK_1_15_FABRIC];
@@ -205,6 +358,29 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 		}
 	};
 
+	const KeyframeGetLerpOriginal = Keyframe.prototype.getLerp;
+	// getLerp(other, axis, amount, allow_expression) {
+	// 	if (allow_expression && this.get(axis) === other.get(axis)) {
+	// 		return this.get(axis)
+	// 	} else {
+	// 		let calc = this.calc(axis)
+	// 		return calc + (other.calc(axis) - calc) * amount
+	// 	}
+	// }
+	function keyframeGetLerp(other, axis, amount, allow_expression) {
+			const easing = this.easing;
+			if (Format.id !== "animated_entity_model") {
+				return KeyframeGetLerpOriginal.apply(this, arguments);
+			}
+			const easingFunc = easingsFunctions[easing];
+			const easedAmount = easingFunc(amount); 
+			const start = this.calc(axis);
+			const stop = other.calc(axis);
+			const result = lerp(start, stop, easedAmount);
+			console.log('keyframeGetLerp arguments:', arguments, 'start:', start, 'stop:', stop, 'amount:', amount, 'easedAmount:', easedAmount, 'result:', result);
+			return result;
+	}
+
 	const KeyframeGetArrayOriginal = Keyframe.prototype.getArray;
 	function keyframeGetArray() {
 			const easing = this.easing;
@@ -263,6 +439,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			Codecs.project.on('parse', parseCallback);
 			Blockbench.on('display_animation_frame', displayAnimationFrameCallback);
 			Blockbench.on('update_keyframe_selection', updateKeyframeSelectionCallback);
+			Keyframe.prototype.getLerp = keyframeGetLerp;
 			Keyframe.prototype.getArray = keyframeGetArray;
 			Keyframe.prototype.getUndoCopy = keyframeGetUndoCopy;
 			Keyframe.prototype.extend = keyframeExtend;
@@ -323,6 +500,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			button.delete();
 			delete global.updateKeyframeEasing;
 	 		Keyframe = KeyframeOriginal;
+			Keyframe.prototype.getLerp = KeyframeGetLerpOriginal;
 			Keyframe.prototype.getArray = KeyframeGetArrayOriginal;
 			Keyframe.prototype.getUndoCopy = KeyframeGetUndoCopyOriginal;
 			Keyframe.prototype.extend = KeyframeExtendOriginal;

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -669,7 +669,7 @@ import software.bernie.geckolib.animation.model.AnimatedModelRenderer;`;
 			addMonkeypatch(global, null, "updateKeyframeEasingArg", updateKeyframeEasingArg);
 
       holdMenu = Animation.prototype.menu.structure.find(x => x.name === 'menu.animation.loop')
-        .children.find(x => x.name !== 'menu.animation.loop.hold');
+        .children.find(x => x.name === 'menu.animation.loop.hold');
       holdMenuConditionOriginal = holdMenu.condition;
       holdMenu.condition = () => Format.id !== "animated_entity_model";
 

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -365,27 +365,26 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 	//#endregion Global Animation UI Handlers
 
 	//#region Keyframe Mixins
-	const Original = {
-	};
+	const Original = new Map();
 	const addMonkeypatch = (symbol, path, functionKey, newFunction) => {
 		const pathAccessor = path ? symbol[path] : symbol;
-		if(!Original[symbol]) Original[symbol] = { _pathAccessor: pathAccessor };
-		Original[symbol][functionKey] = pathAccessor[functionKey];
+		if(!Original.get(symbol)) Original.set(symbol, { _pathAccessor: pathAccessor });
+		Original.get(symbol)[functionKey] = pathAccessor[functionKey];
 		pathAccessor[functionKey] = newFunction;
 	};
 	const removeMonkeypatches = () => {
-		Object.keys(Original).forEach(symbolKey => {
-			const symbol = Original[symbolKey];
+		Original.forEach(symbol => {
 			Object.keys(symbol).forEach(functionKey => {
+				if(functionKey.startsWith('_')) return;
 				symbol._pathAccessor[functionKey] = symbol[functionKey];
 			});
-			delete Original[symbolKey];
 		});
+		Original.clear();
 	}
 	function keyframeGetLerp(other, axis, amount, allow_expression) {
 			const easing = this.easing || EASING_DEFAULT;
 			if (Format.id !== "animated_entity_model") {
-				return Original[Keyframe].getLerp.apply(this, arguments);
+				return Original.get(Keyframe).getLerp.apply(this, arguments);
 			}
 			let easingFunc = easingsFunctions[easing];
 			if (easing.includes("Back")) {
@@ -403,7 +402,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 
 	function keyframeGetArray() {
 			const { easing, easingScale } = this;
-			let result = Original[Keyframe].getArray.apply(this, arguments);
+			let result = Original.get(Keyframe).getArray.apply(this, arguments);
 			if (Format.id === "animated_entity_model") result = { vector: result, easing, easingScale };
 			console.log('keyframeGetArray arguments:', arguments, 'this:', this, 'result:', result);
 			return result;
@@ -411,7 +410,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 
 	function keyframeGetUndoCopy() {
 			const { easing, easingScale } = this;
-			const result = Original[Keyframe].getUndoCopy.apply(this, arguments);
+			const result = Original.get(Keyframe).getUndoCopy.apply(this, arguments);
 			if (Format.id === "animated_entity_model") Object.assign(result, { easing, easingScale });
 			console.log('keyframeGetUndoCopy arguments:', arguments, 'this:', this, 'result:', result);
 			return result;
@@ -437,7 +436,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 				}
 			}
 		}
-		const result = Original[Keyframe].extend.apply(this, arguments);
+		const result = Original.get(Keyframe).extend.apply(this, arguments);
 		console.log('keyframeExtend arguments:', arguments, 'this:', this, 'result:', result);
 		return result;
 	}

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -576,13 +576,13 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 
 	//#region Plugin Definition
 	Plugin.register("animation_utils", {
-		name: "Gecko's Animation Utils",
-		author: "Gecko",
-		title: "Gecko's Animation Utils",
+		name: "Geckolib Animation Utils",
+		author: "Eliot Lash, Gecko",
+		title: "Geckolib Animation Utils",
 		description:
 			"This plugin lets you create animated java entities with GeckoLib. Learn about Geckolib here: https://github.com/bernie-g/geckolib",
 		icon: "movie_filter",
-		version: "1.0.0",
+		version: "2.0.0",
 		variant: "both",
 		onload() {
 			Codecs.project.on('compile', compileCallback);

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -266,86 +266,49 @@
 					};
 			}
 	}
-	
 
-	const easingsFunctions = (function() {
-		const { pow, sin, cos, sqrt, PI } = Math; // TODO delete
-		const quart = Easing.poly(4);
-		const quint = Easing.poly(5);
-		const back = scalar => Easing.back(1.70158 * scalar);
-		const easingsFunctions = {
-			linear: Easing.linear,
-			step(steps, x) {
-				const intervals = stepRange(steps);
-				return intervals[findIntervalBorderIndex(x, intervals, false)];
-			},
-			easeInQuad: Easing.in(Easing.quad),
-			easeOutQuad: Easing.out(Easing.quad),
-			easeInOutQuad: Easing.inOut(Easing.quad),
-			easeInCubic: Easing.in(Easing.cubic),
-			easeOutCubic: Easing.out(Easing.cubic),
-			easeInOutCubic: Easing.inOut(Easing.cubic),
-			easeInQuart: Easing.in(quart),
-			easeOutQuart: Easing.out(quart),
-			easeInOutQuart: Easing.inOut(quart),
-			easeInQuint: Easing.in(quint),
-			easeOutQuint: Easing.out(quint),
-			easeInOutQuint: Easing.inOut(quint),
-			easeInSine: Easing.in(Easing.sin),
-			easeOutSine: Easing.out(Easing.sin),
-			easeInOutSine: Easing.inOut(Easing.sin),
-			easeInExpo: Easing.in(Easing.exp),
-			easeOutExpo: Easing.out(Easing.exp),
-			easeInOutExpo: Easing.inOut(Easing.exp),
-			easeInCirc: Easing.in(Easing.circle),
-			easeOutCirc: Easing.out(Easing.circle),
-			easeInOutCirc: Easing.inOut(Easing.circle),
-				easeInBack(scalar, x) {
-					const c1 = getC1(scalar);
-					const c3 = getC3(c1);
-					return c3 * x * x * x - c1 * x * x;
-				},
-				easeOutBack(scalar, x) {
-					const c1 = getC1(scalar);
-					const c3 = getC3(c1);
-					return 1 + c3 * pow(x - 1, 3) + c1 * pow(x - 1, 2);
-				},
-				easeInOutBack(scalar, x) {
-						const c1 = getC1(scalar);
-						const c2 = getC2(c1);
-						return x < 0.5
-								? (pow(2 * x, 2) * ((c2 + 1) * 2 * x - c2)) / 2
-								: (pow(2 * x - 2, 2) * ((c2 + 1) * (x * 2 - 2) + c2) + 2) / 2;
-				},
-				easeInElastic(x) {
-						return x === 0
-								? 0
-								: x === 1
-										? 1
-										: -pow(2, 10 * x - 10) * sin((x * 10 - 10.75) * c4);
-				},
-				easeOutElastic(x) {
-						return x === 0
-								? 0
-								: x === 1
-										? 1
-										: pow(2, -10 * x) * sin((x * 10 - 0.75) * c4) + 1;
-				},
-				easeInOutElastic(x) {
-						return x === 0
-								? 0
-								: x === 1
-										? 1
-										: x < 0.5
-												? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
-												: (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
-				},
-				easeInBounce: Easing.in(Easing.bounce),
-				easeOutBounce: Easing.out(Easing.bounce),
-				easeInOutBounce: Easing.inOut(Easing.bounce),
-		};
-		return easingsFunctions;
-	})();
+	const quart = Easing.poly(4);
+	const quint = Easing.poly(5);
+	const back = (direction, scalar, t) =>
+		direction(Easing.back(1.70158 * scalar))(t);
+
+	const easingFunctions = {
+		linear: Easing.linear,
+		step(steps, x) {
+			const intervals = stepRange(steps);
+			return intervals[findIntervalBorderIndex(x, intervals, false)];
+		},
+		easeInQuad: Easing.in(Easing.quad),
+		easeOutQuad: Easing.out(Easing.quad),
+		easeInOutQuad: Easing.inOut(Easing.quad),
+		easeInCubic: Easing.in(Easing.cubic),
+		easeOutCubic: Easing.out(Easing.cubic),
+		easeInOutCubic: Easing.inOut(Easing.cubic),
+		easeInQuart: Easing.in(quart),
+		easeOutQuart: Easing.out(quart),
+		easeInOutQuart: Easing.inOut(quart),
+		easeInQuint: Easing.in(quint),
+		easeOutQuint: Easing.out(quint),
+		easeInOutQuint: Easing.inOut(quint),
+		easeInSine: Easing.in(Easing.sin),
+		easeOutSine: Easing.out(Easing.sin),
+		easeInOutSine: Easing.inOut(Easing.sin),
+		easeInExpo: Easing.in(Easing.exp),
+		easeOutExpo: Easing.out(Easing.exp),
+		easeInOutExpo: Easing.inOut(Easing.exp),
+		easeInCirc: Easing.in(Easing.circle),
+		easeOutCirc: Easing.out(Easing.circle),
+		easeInOutCirc: Easing.inOut(Easing.circle),
+		easeInBack: back.bind(null, Easing.in),
+		easeOutBack: back.bind(null, Easing.out),
+		easeInOutBack: back.bind(null, Easing.inOut),
+		easeInElastic: Easing.in(Easing.elastic()), // TODO make configurable
+		easeOutElastic: Easing.out(Easing.elastic()),
+		easeInOutElastic: Easing.inOut(Easing.elastic()),
+		easeInBounce: Easing.in(Easing.bounce),
+		easeOutBounce: Easing.out(Easing.bounce),
+		easeInOutBounce: Easing.inOut(Easing.bounce),
+	};
 
 	const EASING_OPTIONS = {
 		linear: "linear",
@@ -609,7 +572,7 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			if (Format.id !== "animated_entity_model") {
 				return Original.get(Keyframe).getLerp.apply(this, arguments);
 			}
-			let easingFunc = easingsFunctions[easing];
+			let easingFunc = easingFunctions[easing];
 			if (hasArgs(easing)) {
 				const arg1 = Array.isArray(other.easingArgs) && other.easingArgs.length > 0
 					? other.easingArgs[0]

--- a/plugins/animation_utils.js
+++ b/plugins/animation_utils.js
@@ -23,6 +23,10 @@
 			return acc;
 		}, []);
 	}
+
+	function compose(...fns) {
+		 return x => fns.reduceRight((y, f) => f(y), x);
+	}
 	//#endregion Helper Functions
 
 	//#region Easing Functions
@@ -88,112 +92,214 @@
 		}, (_, i) => i * stepLength);
 	};
 
+	// The MIT license notice below applies to the Easing class
+	/**
+	 * Copyright (c) Facebook, Inc. and its affiliates.
+	 *
+	 * This source code is licensed under the MIT license found in the
+	 * LICENSE file in the root directory of this source tree.
+	 */
+	class Easing {
+			/**
+			 * A stepping function, returns 1 for any positive value of `n`.
+			 */
+			static step0(n) {
+					return n > 0 ? 1 : 0;
+			}
+			/**
+			 * A stepping function, returns 1 if `n` is greater than or equal to 1.
+			 */
+			static step1(n) {
+					return n >= 1 ? 1 : 0;
+			}
+			/**
+			 * A linear function, `f(t) = t`. Position correlates to elapsed time one to
+			 * one.
+			 *
+			 * http://cubic-bezier.com/#0,0,1,1
+			 */
+			static linear(t) {
+					return t;
+			}
+			/**
+			 * A simple inertial interaction, similar to an object slowly accelerating to
+			 * speed.
+			 *
+			 * http://cubic-bezier.com/#.42,0,1,1
+			 */
+			// static ease(t) {
+			// 		if (!ease) {
+			// 				ease = Easing.bezier(0.42, 0, 1, 1);
+			// 		}
+			// 		return ease(t);
+			// }
+			/**
+			 * A quadratic function, `f(t) = t * t`. Position equals the square of elapsed
+			 * time.
+			 *
+			 * http://easings.net/#easeInQuad
+			 */
+			static quad(t) {
+					return t * t;
+			}
+			/**
+			 * A cubic function, `f(t) = t * t * t`. Position equals the cube of elapsed
+			 * time.
+			 *
+			 * http://easings.net/#easeInCubic
+			 */
+			static cubic(t) {
+					return t * t * t;
+			}
+			/**
+			 * A power function. Position is equal to the Nth power of elapsed time.
+			 *
+			 * n = 4: http://easings.net/#easeInQuart
+			 * n = 5: http://easings.net/#easeInQuint
+			 */
+			static poly(n) {
+					return (t) => Math.pow(t, n);
+			}
+			/**
+			 * A sinusoidal function.
+			 *
+			 * http://easings.net/#easeInSine
+			 */
+			static sin(t) {
+					return 1 - Math.cos((t * Math.PI) / 2);
+			}
+			/**
+			 * A circular function.
+			 *
+			 * http://easings.net/#easeInCirc
+			 */
+			static circle(t) {
+					return 1 - Math.sqrt(1 - t * t);
+			}
+			/**
+			 * An exponential function.
+			 *
+			 * http://easings.net/#easeInExpo
+			 */
+			static exp(t) {
+					return Math.pow(2, 10 * (t - 1));
+			}
+			/**
+			 * A simple elastic interaction, similar to a spring oscillating back and
+			 * forth.
+			 *
+			 * Default bounciness is 1, which overshoots a little bit once. 0 bounciness
+			 * doesn't overshoot at all, and bounciness of N > 1 will overshoot about N
+			 * times.
+			 *
+			 * http://easings.net/#easeInElastic
+			 */
+			static elastic(bounciness = 1) {
+					const p = bounciness * Math.PI;
+					return t => 1 - Math.pow(Math.cos((t * Math.PI) / 2), 3) * Math.cos(t * p);
+			}
+			/**
+			 * Use with `Animated.parallel()` to create a simple effect where the object
+			 * animates back slightly as the animation starts.
+			 *
+			 * Wolfram Plot:
+			 *
+			 * - http://tiny.cc/back_default (s = 1.70158, default)
+			 */
+			static back(s = 1.70158) {
+					return t => t * t * ((s + 1) * t - s);
+			}
+			/**
+			 * Provides a simple bouncing effect.
+			 *
+			 * http://easings.net/#easeInBounce
+			 */
+			static bounce(t) {
+					if (t < 1 / 2.75) {
+							return 7.5625 * t * t;
+					}
+					if (t < 2 / 2.75) {
+							const t2 = t - 1.5 / 2.75;
+							return 7.5625 * t2 * t2 + 0.75;
+					}
+					if (t < 2.5 / 2.75) {
+							const t2 = t - 2.25 / 2.75;
+							return 7.5625 * t2 * t2 + 0.9375;
+					}
+					const t2 = t - 2.625 / 2.75;
+					return 7.5625 * t2 * t2 + 0.984375;
+			}
+			/**
+			 * Provides a cubic bezier curve, equivalent to CSS Transitions'
+			 * `transition-timing-function`.
+			 *
+			 * A useful tool to visualize cubic bezier curves can be found at
+			 * http://cubic-bezier.com/
+			 */
+			// static bezier(x1, y1, x2, y2) {
+			// 		const _bezier = require('./bezier');
+			// 		return _bezier(x1, y1, x2, y2);
+			// }
+			/**
+			 * Runs an easing function forwards.
+			 */
+			static in(easing) {
+					return easing;
+			}
+			/**
+			 * Runs an easing function backwards.
+			 */
+			static out(easing) {
+					return t => 1 - easing(1 - t);
+			}
+			/**
+			 * Makes any easing function symmetrical. The easing function will run
+			 * forwards for half of the duration, then backwards for the rest of the
+			 * duration.
+			 */
+			static inOut(easing) {
+					return t => {
+							if (t < 0.5) {
+									return easing(t * 2) / 2;
+							}
+							return 1 - easing((1 - t) * 2) / 2;
+					};
+			}
+	}
+	
+
 	const easingsFunctions = (function() {
-		const pow = Math.pow;
-		const sqrt = Math.sqrt;
-		const sin = Math.sin;
-		const cos = Math.cos;
-		const PI = Math.PI;
-		const getC1 = scalar => 1.70158 * scalar;
-		const getC2 = c1 => c1 * 1.525;
-		const getC3 = c1 => c1 + 1;
-		const c4 = (2 * PI) / 3;
-		const c5 = (2 * PI) / 4.5;
-		function bounceOut(x) {
-				const n1 = 7.5625;
-				const d1 = 2.75;
-				if (x < 1 / d1) {
-						return n1 * x * x;
-				}
-				else if (x < 2 / d1) {
-						return n1 * (x -= 1.5 / d1) * x + 0.75;
-				}
-				else if (x < 2.5 / d1) {
-						return n1 * (x -= 2.25 / d1) * x + 0.9375;
-				}
-				else {
-						return n1 * (x -= 2.625 / d1) * x + 0.984375;
-				}
-		}
+		const { pow, sin, cos, sqrt, PI } = Math; // TODO delete
+		const quart = Easing.poly(4);
+		const quint = Easing.poly(5);
+		const back = scalar => Easing.back(1.70158 * scalar);
 		const easingsFunctions = {
-				linear(x) {
-					return x;
-				},
-				step(steps, x) {
-					const intervals = stepRange(steps);
-					return intervals[findIntervalBorderIndex(x, intervals, false)];
-				},
-				easeInQuad(x) {
-						return x * x;
-				},
-				easeOutQuad(x) {
-						return 1 - (1 - x) * (1 - x);
-				},
-				easeInOutQuad(x) {
-						return x < 0.5 ? 2 * x * x : 1 - pow(-2 * x + 2, 2) / 2;
-				},
-				easeInCubic(x) {
-						return x * x * x;
-				},
-				easeOutCubic(x) {
-						return 1 - pow(1 - x, 3);
-				},
-				easeInOutCubic(x) {
-						return x < 0.5 ? 4 * x * x * x : 1 - pow(-2 * x + 2, 3) / 2;
-				},
-				easeInQuart(x) {
-						return x * x * x * x;
-				},
-				easeOutQuart(x) {
-						return 1 - pow(1 - x, 4);
-				},
-				easeInOutQuart(x) {
-						return x < 0.5 ? 8 * x * x * x * x : 1 - pow(-2 * x + 2, 4) / 2;
-				},
-				easeInQuint(x) {
-						return x * x * x * x * x;
-				},
-				easeOutQuint(x) {
-						return 1 - pow(1 - x, 5);
-				},
-				easeInOutQuint(x) {
-						return x < 0.5 ? 16 * x * x * x * x * x : 1 - pow(-2 * x + 2, 5) / 2;
-				},
-				easeInSine(x) {
-						return 1 - cos((x * PI) / 2);
-				},
-				easeOutSine(x) {
-						return sin((x * PI) / 2);
-				},
-				easeInOutSine(x) {
-						return -(cos(PI * x) - 1) / 2;
-				},
-				easeInExpo(x) {
-						return x === 0 ? 0 : pow(2, 10 * x - 10);
-				},
-				easeOutExpo(x) {
-						return x === 1 ? 1 : 1 - pow(2, -10 * x);
-				},
-				easeInOutExpo(x) {
-						return x === 0
-								? 0
-								: x === 1
-										? 1
-										: x < 0.5
-												? pow(2, 20 * x - 10) / 2
-												: (2 - pow(2, -20 * x + 10)) / 2;
-				},
-				easeInCirc(x) {
-						return 1 - sqrt(1 - pow(x, 2));
-				},
-				easeOutCirc(x) {
-						return sqrt(1 - pow(x - 1, 2));
-				},
-				easeInOutCirc(x) {
-						return x < 0.5
-								? (1 - sqrt(1 - pow(2 * x, 2))) / 2
-								: (sqrt(1 - pow(-2 * x + 2, 2)) + 1) / 2;
-				},
+			linear: Easing.linear,
+			step(steps, x) {
+				const intervals = stepRange(steps);
+				return intervals[findIntervalBorderIndex(x, intervals, false)];
+			},
+			easeInQuad: Easing.in(Easing.quad),
+			easeOutQuad: Easing.out(Easing.quad),
+			easeInOutQuad: Easing.inOut(Easing.quad),
+			easeInCubic: Easing.in(Easing.cubic),
+			easeOutCubic: Easing.out(Easing.cubic),
+			easeInOutCubic: Easing.inOut(Easing.cubic),
+			easeInQuart: Easing.in(quart),
+			easeOutQuart: Easing.out(quart),
+			easeInOutQuart: Easing.inOut(quart),
+			easeInQuint: Easing.in(quint),
+			easeOutQuint: Easing.out(quint),
+			easeInOutQuint: Easing.inOut(quint),
+			easeInSine: Easing.in(Easing.sin),
+			easeOutSine: Easing.out(Easing.sin),
+			easeInOutSine: Easing.inOut(Easing.sin),
+			easeInExpo: Easing.in(Easing.exp),
+			easeOutExpo: Easing.out(Easing.exp),
+			easeInOutExpo: Easing.inOut(Easing.exp),
+			easeInCirc: Easing.in(Easing.circle),
+			easeOutCirc: Easing.out(Easing.circle),
+			easeInOutCirc: Easing.inOut(Easing.circle),
 				easeInBack(scalar, x) {
 					const c1 = getC1(scalar);
 					const c3 = getC3(c1);
@@ -234,15 +340,9 @@
 												? -(pow(2, 20 * x - 10) * sin((20 * x - 11.125) * c5)) / 2
 												: (pow(2, -20 * x + 10) * sin((20 * x - 11.125) * c5)) / 2 + 1;
 				},
-				easeInBounce(x) {
-						return 1 - bounceOut(1 - x);
-				},
-				easeOutBounce: bounceOut,
-				easeInOutBounce(x) {
-						return x < 0.5
-								? (1 - bounceOut(1 - 2 * x)) / 2
-								: (1 + bounceOut(2 * x - 1)) / 2;
-				},
+				easeInBounce: Easing.in(Easing.bounce),
+				easeOutBounce: Easing.out(Easing.bounce),
+				easeInOutBounce: Easing.inOut(Easing.bounce),
 		};
 		return easingsFunctions;
 	})();
@@ -521,7 +621,10 @@ import software.bernie.geckolib.forgetofabric.ResourceLocation;`;
 			const start = this.calc(axis);
 			const stop = other.calc(axis);
 			const result = lerp(start, stop, easedAmount);
-			console.log('keyframeGetLerp arguments:', arguments, 'start:', start, 'stop:', stop, 'amount:', amount, 'easedAmount:', easedAmount, 'result:', result);
+			console.log('keyframeGetLerp easing:', easing, 'arguments:', arguments, 'start:', start, 'stop:', stop, 'amount:', amount, 'easedAmount:', easedAmount, 'result:', result);
+			if (Number.isNaN(result)) {
+				throw new Error('batman');
+			}
 			return result;
 	}
 


### PR DESCRIPTION
I have been working hard on this major update to the GeckoLib Animation Utils. New features include:

- Per keyframe easing settings, implementing all curves from easings.net as well as step curve
- Ability to adjust curve shapes for elastic, bounce, and back
- Support for Forge 1.15 and Fabric 1.15 Java code templates
- Optional settings to allow user to customize package, entity type parameter, and animation file path so exported Java code is ready to build and run with no manual modifications needed
- Temporarily disabled some blockbench features for animated java entity projects that we don't yet support to minimize user confusion (hold on last frame loop type and "reverse keyframes" action)

Note that I followed your guidance that we should override/monkeypatch functions to add functionality we need. I tried to do this in as clean a manner as possible, scope new behaviors to our project type only, and undo everything when the plugin is installed. However, I am a bit worried about long-term maintenance as this plugin could break if any of the internals we're messing with change in future releases. So perhaps we should discuss if we can negotiate an API contract for some of this.

I am hoping to add more improvements soon, you can see our roadmap at https://trello.com/b/MhCzRUmf/geckolib-todo

![easing](https://user-images.githubusercontent.com/110764/87962934-d6f6d200-ca6c-11ea-9a75-3ed507d69515.gif)
![bounce3](https://user-images.githubusercontent.com/110764/87962951-da8a5900-ca6c-11ea-9c9b-e23dfa510472.gif)
<img width="550" alt="Screen Shot 2020-07-20 at 9 39 56 AM" src="https://user-images.githubusercontent.com/110764/87963060-fe4d9f00-ca6c-11ea-8d62-97d04e7801d3.png">

