### PR TITLE
Initial duplicate renamer plugin commit

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -251,5 +251,13 @@
         "description": "Hide everything except for the selected cubes",
         "version": "0.0.1",
         "variant": "both"
-    }
+    },
+	"duplicate_renamer": {
+		"title": "Duplicate Bone Renamer",
+		"icon": "fa-font",
+		"author": "Gecko",
+		"description": "This plugin renames duplicate bones so they work in bedrock and GeckoLib models",
+		"version": "1.0.0",
+		"variant": "both"
+	}
 }

--- a/plugins/duplicate_renamer.js
+++ b/plugins/duplicate_renamer.js
@@ -9,8 +9,6 @@
         version: '1.0.0',
         variant: 'both',
         onload() {
-            // add a button to show the tips
-            console.log("here")
             button = new Action('rename_duplicates', {
                 name: 'Rename Duplicates',
                 description: 'Rename all duplicate bone names',

--- a/plugins/duplicate_renamer.js
+++ b/plugins/duplicate_renamer.js
@@ -1,0 +1,43 @@
+(function () {
+    // Register plugin
+    Plugin.register('duplicate_renamer', {
+        title: 'Duplicate Bone Renamer',
+        author: 'Gecko',
+        icon: 'fa-font',
+        description: 'This plugin renames duplicate bones so they work in bedrock and GeckoLib',
+        about: 'Simply go to Edit -> Rename Duplicates. All duplicate bones will get renamed to {bone}_{number}',
+        version: '1.0.0',
+        variant: 'both',
+        onload() {
+            // add a button to show the tips
+            console.log("here")
+            button = new Action('rename_duplicates', {
+                name: 'Rename Duplicates',
+                description: 'Rename all duplicate bone names',
+                icon: 'fa-font',
+                click: function () {
+                    Undo.initEdit({outliner: true});
+                    const duplicates = []
+                    Group.all.forEach(x => {
+                        if (duplicates.some(group => group.name === x.name)) {
+                            let duplicate = duplicates.find(group => group.name === x.name);
+                            x.name += "_" + duplicate.number;
+                            duplicate.number++;
+                        }
+                        else {
+                            duplicates.push({
+                                name: x.name,
+                                number: 1
+                            })
+                        }
+                    })
+                    Undo.finishEdit('rename duplicates', {outliner: true});
+                }
+            });
+            MenuBar.addAction(button, 'edit.-1');
+        },
+        onunload() {
+            button.delete();
+        }
+    });
+})();


### PR DESCRIPTION
This plugin adds an action that renames all duplicate bones automatically so that exported bedrock models are able to load fine in bedrock edition and geckolib