### PR TITLE
Added Double Sided Cubes Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -21,6 +21,14 @@
 		"description": "Highlights missing textures by flashing them.",
 		"variant": "both"
 	},
+	"double_sided_cubes": {
+		"title": "Double Sided Cube Generator",
+		"author": "SnaveSutit",
+		"icon": "flip_to_back",
+		"description": "Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.",
+		"version": "1.0.0",
+		"variant": "both"
+	},
 	"optimize": {
 		"title": "Optimize",
 		"author": "Krozi",

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -1,4 +1,37 @@
 (()=> {
+	const cube_action = new Action({
+		id:"create_double_sided_cubes",
+		name: 'Create Double Sided Cube',
+		icon: 'flip_to_back',
+		category: 'edit',
+		condition: () => !Project.box_uv,
+		click: function(ev) {
+			if (selected.length === 0) {
+				Blockbench.showMessage('No cubes selected', 'center')
+				return;
+			};
+			Undo.initEdit({elements:[]});
+			let cubes = [];
+			Cube.selected.forEach((cube) => {
+				const new_cube = new Cube({...cube}).init();
+				new_cube.name = new_cube.name + " inverted";
+				if (cube.parent !== "root") {
+					new_cube.addTo(cube.parent);
+				};
+				for (i=0; i<3; i++){
+					new_cube.flip(i, 0, false)
+				};
+				new_cube.from = [...cube.to];
+				new_cube.to = [...cube.from];
+				new_cube.inflate = -new_cube.inflate;
+				Canvas.adaptObjectPosition(new_cube);
+				Canvas.updateUV(new_cube);
+				cubes.push(new_cube);
+			});
+			Undo.finishEdit('create_double_sided_cube', {elements:cubes});
+		}
+	});
+
 	Plugin.register('double_sided_cubes', {
 		title: 'Double Sided Cubes',
 		author: 'SnaveSutit',
@@ -7,39 +40,10 @@
 		version: '1.0.0',
 		variant: 'both',
 		onload() {
-			cube_action = new Action({
-				id:"create_double_sided_cubes",
-				name: 'Create Double Sided Cube',
-		    icon: 'flip_to_back',
-		    category: 'edit',
-		    condition: () => !Project.box_uv,
-		    click: function(ev) {
-		    	if (selected.length === 0) {
-						Blockbench.showMessage('No cubes selected', 'center')
-						return;
-					}
-					Undo.initEdit({elements:[]});
-					let cubes = [];
-					Cube.selected.forEach((cube) => {
-						new_cube = new Cube({...cube}).init();
-						new_cube.name = new_cube.name + " inverted";
-						if (cube.parent !== "root") {new_cube.addTo(cube.parent)};
-						for (i=0; i<3; i++){
-							new_cube.flip(i, 0, false)
-						};
-						new_cube.from = [...cube.to];
-						new_cube.to = [...cube.from];
-						new_cube.inflate = new_cube.inflate * -1;
-						cubes.push(new_cube);
-					});
-					Undo.finishEdit('create_double_sided_cube', {elements:cubes});
-					Canvas.updateAll();
-				}
-			});
-			MenuBar.addAction(cube_action, 'filter')
+			MenuBar.addAction(cube_action, 'filter');
 		},
 		onunload() {
-			cube_action.delete()
+			cube_action.delete();
 		}
 	});
 })();

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -1,36 +1,6 @@
 (()=> {
-	const cube_action = new Action({
-		id:"create_double_sided_cubes",
-		name: 'Create Double Sided Cube',
-		icon: 'flip_to_back',
-		category: 'edit',
-		condition: () => !Project.box_uv,
-		click: function(ev) {
-			if (selected.length === 0) {
-				Blockbench.showMessage('No cubes selected', 'center')
-				return;
-			};
-			Undo.initEdit({elements:[]});
-			let cubes = [];
-			Cube.selected.forEach((cube) => {
-				const new_cube = new Cube({...cube}).init();
-				new_cube.name = new_cube.name + " inverted";
-				if (cube.parent !== "root") {
-					new_cube.addTo(cube.parent);
-				};
-				for (i=0; i<3; i++){
-					new_cube.flip(i, 0, false)
-				};
-				new_cube.from = [...cube.to];
-				new_cube.to = [...cube.from];
-				new_cube.inflate = -new_cube.inflate;
-				Canvas.adaptObjectPosition(new_cube);
-				Canvas.updateUV(new_cube);
-				cubes.push(new_cube);
-			});
-			Undo.finishEdit('create_double_sided_cube', {elements:cubes});
-		}
-	});
+
+	let cube_action;
 
 	Plugin.register('double_sided_cubes', {
 		title: 'Double Sided Cubes',
@@ -40,6 +10,38 @@
 		version: '1.0.0',
 		variant: 'both',
 		onload() {
+			cube_action = new Action({
+				id:"create_double_sided_cubes",
+				name: 'Create Double Sided Cube',
+				icon: 'flip_to_back',
+				category: 'edit',
+				condition: () => !Project.box_uv,
+				click: function(ev) {
+					if (selected.length === 0) {
+						Blockbench.showMessage('No cubes selected', 'center')
+						return;
+					};
+					Undo.initEdit({elements:[]});
+					let cubes = [];
+					Cube.selected.forEach((cube) => {
+						const new_cube = new Cube({...cube}).init();
+						new_cube.name = new_cube.name + " inverted";
+						if (cube.parent !== "root") {
+							new_cube.addTo(cube.parent);
+						};
+						for (i=0; i<3; i++){
+							new_cube.flip(i, 0, false)
+						};
+						new_cube.from = [...cube.to];
+						new_cube.to = [...cube.from];
+						new_cube.inflate = -new_cube.inflate;
+						Canvas.adaptObjectPosition(new_cube);
+						Canvas.updateUV(new_cube);
+						cubes.push(new_cube);
+					});
+					Undo.finishEdit('create_double_sided_cube', {elements:cubes});
+				}
+			});
 			MenuBar.addAction(cube_action, 'filter');
 		},
 		onunload() {

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -1,0 +1,45 @@
+(()=> {
+	Plugin.register('double_sided_cubes', {
+		title: 'Double Sided Cubes',
+		author: 'SnaveSutit',
+		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
+		icon: 'flip_to_back',
+		version: '1.0.0',
+		variant: 'both',
+		onload() {
+			cube_action = new Action({
+				id:"create_double_sided_cubes",
+				name: 'Create Double Sided Cube',
+		    icon: 'flip_to_back',
+		    category: 'edit',
+		    condition: () => !Project.box_uv,
+		    click: function(ev) {
+		    	if (selected.length === 0) {
+						Blockbench.showMessage('No cubes selected', 'center')
+						return;
+					}
+					Undo.initEdit({elements:[]});
+					let cubes = [];
+					Cube.selected.forEach((cube) => {
+						new_cube = new Cube({...cube}).init();
+						new_cube.name = new_cube.name + " inverted";
+						if (cube.parent !== "root") {new_cube.addTo(cube.parent)};
+						for (i=0; i<3; i++){
+							new_cube.flip(i, 0, false)
+						};
+						new_cube.from = [...cube.to];
+						new_cube.to = [...cube.from];
+						new_cube.inflate = new_cube.inflate * -1;
+						cubes.push(new_cube);
+					});
+					Undo.finishEdit('create_double_sided_cube', {elements:cubes});
+					Canvas.updateAll();
+				}
+			});
+			MenuBar.addAction(cube_action, 'filter')
+		},
+		onunload() {
+			cube_action.delete()
+		}
+	});
+})();


### PR DESCRIPTION
Simply duplicates the selected Cube(s), flips them on all axis, inverts their scale and inflation, and fixes their position to line up with the original cube. This inversion causes a double sided rendering effect on java and I thought it would be nice to have a simple plugin that does all of these actions for you. Thanks to dragonmaster95#3249 for the solution to double sided rendering that doesn't require a plane per face of the cube.