### PR TITLE
Fixed Armor Stand Animator for 4.0 and fixed an issue in Command Master's Animator plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -6,8 +6,8 @@
 		"about": "To start, create the armor stand model by using the \"Create Armor Stand Model\" action in the toolbar. Then, create your animation in the animate tab as normal. Make sure the snapping value for keyframes is set to 20 for best results. When you're finished, use the \"Export Armor Stand Animation\" action in the toolbar. Change the settings as needed, then click \"Confirm\". Animations can be run with \"/execute as @e[tag=entity_tag] run function animation_pack:start\". The armor stand for an animation can be summoned with \"/function animation_pack:create\". Supports looping, time scale, block/blockbench unit scale, and start delays.",
 		"tags": ["Minecraft: Java Edition"],
 		"icon": "fa-forward",
-		"version": "1.0.0",
-		"min_version": "3.1.0",
+		"version": "1.0.1",
+		"min_version": "4.0.0",
 		"variant": "both"
 	},
 	"animator": {

--- a/plugins/animator.js
+++ b/plugins/animator.js
@@ -11,7 +11,7 @@
 To use click Filter -> Save starting model the save the first model, and then click on File -> Export -> Export animation to download the ZIP file of the animation`,
         tags: ["Minecraft: Java Edition"],
         icon: 'compare',
-        version: '1.0.0',
+        version: '1.0.1',
         variant: 'both',
         onload() {
             types = ['thirdperson_righthand', 'thirdperson_lefthand', 'firstperson_righthand', 'firstperson_lefthand', 'gui', 'head', 'ground', 'fixed'];
@@ -192,7 +192,7 @@ To use click Filter -> Save starting model the save the first model, and then cl
                 type: 'Zip Archive',
                 extensions: ['zip'],
                 name: 'animation',
-                startpath: ModelMeta.export_path,
+                startpath: Project.export_path,
                 content: content,
                 savetype: 'zip'
             })

--- a/plugins/armor_stand_animator.js
+++ b/plugins/armor_stand_animator.js
@@ -124,7 +124,7 @@ function generatePackFromAnimation(animationContents, animationName, configData,
     
     zip.generateAsync({type: "blob"}).then(content => {
         Blockbench.export({
-            startpath: ModelMeta.export_path,
+            startpath: Project.export_path,
             type: "Zip Archive",
             extensions: ["zip"],
             name: animationName,
@@ -141,7 +141,7 @@ function generatePackFromAnimation(animationContents, animationName, configData,
         description: "Provides an interface to animate armor stands which is converted to a data pack",
         tags: ["Minecraft: Java Edition"],
         icon: "fa-forward",
-        version: "1.0.0",
+        version: "1.0.1",
         variant: "both",
         onload() {
             // Both actions are globals


### PR DESCRIPTION
I have permission from Command Master to do this change.
I can't guarantee his plugin will work with this change, but it does fix the same issue Armor Stand Animator had.