### PR TITLE
Update double_sided_cubes.js

### DIFF
--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -36,6 +36,7 @@
 						new_cube.from = [...cube.to];
 						new_cube.to = [...cube.from];
 						new_cube.inflate = -new_cube.inflate;
+						new_cube.origin = [-new_cube.origin[0],-new_cube.origin[1],-new_cube.origin[2]];
 						Canvas.adaptObjectPosition(new_cube);
 						Canvas.updateUV(new_cube);
 						cubes.push(new_cube);


### PR DESCRIPTION
A fix so rotated elements aren't all over the place due to inverted pivot points.