### PR TITLE
Add Cardinal [Plugin]

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -423,5 +423,14 @@
 		"description": "Randomize the Brush Color with each stroke to give your artwork more variation",
 		"version": "1.0.0",
 		"variant": "both"
+	},
+	"cardinal": {
+		"title": "Cardinal",
+		"author": "Bug1312",
+		"icon": "border_outer",
+		"description": "Adds in all cardinal directions on the grid and renders them on-top of everything while facing the camera.",
+		"about": "If you wish to change the color, use custom CSS to set the variable 'cardinal' to any color!",
+		"version": "1.0.0",
+		"variant": "both"
 	}
 }

--- a/plugins/cardinal.js
+++ b/plugins/cardinal.js
@@ -1,0 +1,83 @@
+(function() {
+
+	let images = {
+			north: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKAQMAAAC3/F3+AAAABlBMVEVHcEz///+flKJDAAAAAXRSTlMAQObYZgAAABVJREFUCNdjSGxgAKJKMEoHo0QEAgCIGwkHoSKsGQAAAABJRU5ErkJggg",
+			east : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFAQMAAAC3obSmAAAABlBMVEVHcEz///+flKJDAAAAAXRSTlMAQObYZgAAABBJREFUCNdjKGBwYEgA4gIACMoBwSwi6WsAAAAASUVORK5CYII",
+			south: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFAQMAAAC3obSmAAAABlBMVEVHcEz///+flKJDAAAAAXRSTlMAQObYZgAAABJJREFUCNdjKGBwYChgEGAoAAAIigGhv1KChwAAAABJRU5ErkJggg",
+			west : "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKAQMAAAC3/F3+AAAABlBMVEVHcEz///+flKJDAAAAAXRSTlMAQObYZgAAABhJREFUCNdjYGBgOHAAhM4gIWMGEGJgAACnnQmX+CnbdwAAAABJRU5ErkJggg"
+		},
+		buildGridCopy = buildGrid;
+
+	Plugin.register("cardinal", {
+		title: "Cardinal",
+		author: "Bug1312",
+		description: "Adds in all cardinal directions on the grid and renders them on-top of everything while facing the camera.",
+		about: "If you wish to change the color, use custom CSS to set the variable 'cardinal' to any color!",
+		icon: "border_outer",
+		version: "1.0.0",
+		variant: "both",
+		onload() {
+			window.buildGrid = function() {
+				// Default grid
+				buildGridCopy();
+
+				// Hide default north mark
+				three_grid.children.find(c => c.material === Canvas.northMarkMaterial).visible = false;
+
+				// Generate other marks
+				addMark(images.north, [ 0.0, -9.5 ]);
+				addMark(images.east,  [ 9.5,  0.0 ]);
+				addMark(images.south, [ 0.0,  9.5 ]);
+				addMark(images.west,  [-9.5,  0.0 ]);
+			};
+			buildGrid();
+		},
+		onunload() { window.buildGrid = buildGridCopy },
+		onuninstall() { buildGrid() }
+	});
+
+	function addMark(src, pos) {
+		let img = new Image(),
+			tex = new THREE.Texture(img),
+			color = getComputedStyle(document.body).getPropertyValue("--cardinal").replace(/^\s*/, "");
+
+		if (color === "") color = "#FFF";
+
+		// Set textures to src
+		img.src = src;
+		img.tex = tex;
+
+		// Render pixelated
+		img.tex.magFilter = THREE.NearestFilter;
+		img.tex.minFilter = THREE.NearestFilter;
+
+		// When loaded, render texture but only do so after onBeforeRender()
+		//	Results in less flashing
+		img.onload = function() { this.tex.needsUpdate = true };
+
+		// Setup cardinal mark
+		let geometry = new THREE.PlaneGeometry(2.4, 2.4),
+			material = new THREE.MeshBasicMaterial({
+				map: tex,
+				transparent: true,
+				color: new THREE.Color(color)
+			}),
+			mark = new THREE.Mesh(geometry, material);
+
+		// Render on top
+		mark.renderOrder = 10;
+		mark.material.depthTest  = false;
+		mark.material.depthWrite = false;
+
+		// Look at camera
+		mark.onBeforeRender = function() { this.lookAt(main_preview.camera.position) };
+
+		// Move marks based on grid positioning
+		if (Format.centered_grid) mark.position.set(pos[0], 0, pos[1]);
+		else mark.position.set(pos[0] + 8, 0, pos[1] + 8);
+
+		// Add to grid
+		three_grid.add(mark);
+	}
+
+})();


### PR DESCRIPTION
Cardinal is a quality of life plugin that changes up the Blockbench grid to have all cardinal directions as well as render them over the model. When removing, grid will automatically change back.
If you use custom CSS you can set the root variable "--cardial" (which is a color) to change the color of the cardinal notations.
![image](https://user-images.githubusercontent.com/59811382/152088350-2b882b59-e898-497b-a2e1-9aa85b2e7b22.png)
(Custom CSS showcase)
![image](https://user-images.githubusercontent.com/59811382/152088390-4a54b405-2a47-4c10-8fc8-bf478fa46bad.png)
![image](https://user-images.githubusercontent.com/59811382/152089440-5c66a784-4bc0-42d9-afe4-e404a5e99d35.png)
