### PR TITLE
Root Motion Extractor update

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -554,7 +554,7 @@
 		"description": "Attempts to extract root motion from an animation",
 		"about" : "This plugin extracts the velocity in m/s for an animation, and provides a value to be used in a movement component to achieve that exact speed. This helps reduce/eliminate foot sliding.",
 		"tags": ["Minecraft: Bedrock Edition", "Animation", "Root Motion"],
-		"version": "1.0.0",
+		"version": "1.0.1",
 		"variant": "both"
 	}
 }

--- a/plugins/root_motion_extractor.js
+++ b/plugins/root_motion_extractor.js
@@ -44,7 +44,7 @@
         icon: "fa-exchange",
         author: "Tschipp",
         description: "Attempts to extract root motion from an animation",
-        version: "1.0.0",
+        version: "1.0.1",
         tags: ["Minecraft: Bedrock Edition"],
         onload() {
             Blockbench.on("select_mode", (event) => {
@@ -168,7 +168,8 @@
     {
         if(processingMotion)
         {
-            if(Timeline.time >= Timeline.animation_length)
+            let length = Timeline.animation_length > 0 ? Timeline.animation_length : 10;
+            if(Timeline.time >= length)
             {
                 console.log("Finished processing motion");
                 Blockbench.showQuickMessage('Finished extracting root motion');


### PR DESCRIPTION
Fixed issue where the plugin didn't work for animations with length 0.