### PR TITLE
added rounding function to animation_to_java.js to fix formatting

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -576,7 +576,7 @@
 		"author": "MG,Vincent_Huto(PR),DailyCraft(PR)",
 		"description": "Converts Blockbench animations to Java code for the new 1.19 keyframe system",
 		"icon": "fa-cube",
-		"version": "1.1.1",
+		"version": "1.1.2",
 		"variant": "both",
 		"about": "This plugin exports your blockbench animations as java code to be used for the new 1.19 keyframe system. Please note that this system does not support Molang or step interpolation",
 		"tags": ["Minecraft: Java Edition"]

--- a/plugins/animation_to_java.js
+++ b/plugins/animation_to_java.js
@@ -59,7 +59,7 @@ function generateFile() {
       let scaleKeyArray = [];
 
       if (boneAnimator.position.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}",\n new AnimationChannel(AnimationChannel.Targets.POSITION`;
+        outfileText += `\n.addAnimation("${boneAnimator.name}",\n\tnew AnimationChannel(AnimationChannel.Targets.POSITION`;
         //Sorts by time to ensure ordering
         for (const keyFrame of boneAnimator.position) {
           posKeyArray.push(keyFrame);
@@ -68,13 +68,13 @@ function generateFile() {
 
         for (const keyFrame of posKeyArray) {
           var { x, y, z } = keyFrame.data_points[0];
-          outfileText += `, \n new Keyframe(${round2(keyFrame.time)
-            }f, KeyframeAnimations.posVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          outfileText += `, \n\t\tnew Keyframe(${keyFrame.time
+            }f, KeyframeAnimations.posVec(${x}f, ${y}f, ${z}f),\n\t\t\tAnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
       }
       if (boneAnimator.rotation.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}",\n new AnimationChannel(AnimationChannel.Targets.ROTATION`;
+        outfileText += `\n.addAnimation("${boneAnimator.name}",\n\tnew AnimationChannel(AnimationChannel.Targets.ROTATION`;
         //Sorts by time to ensure ordering
         for (const keyFrame of boneAnimator.rotation) {
           rotKeyArray.push(keyFrame);
@@ -83,13 +83,13 @@ function generateFile() {
 
         for (const keyFrame of rotKeyArray) {
           var { x, y, z } = keyFrame.data_points[0];
-          outfileText += `,\n new Keyframe(${round2(keyFrame.time)
-            }f, KeyframeAnimations.degreeVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          outfileText += `,\n\t\tnew Keyframe(${keyFrame.time
+            }f, KeyframeAnimations.degreeVec(${x}f, ${y}f, ${z}f),\n\t\t\tAnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
       }
       if (boneAnimator.scale.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}", \n new AnimationChannel(AnimationChannel.Targets.SCALE`;
+        outfileText += `\n.addAnimation("${boneAnimator.name}",\n\tnew AnimationChannel(AnimationChannel.Targets.SCALE`;
         //Sorts by time to ensure ordering
         for (const keyFrame of boneAnimator.scale) {
           scaleKeyArray.push(keyFrame);
@@ -98,17 +98,17 @@ function generateFile() {
 
         for (const keyFrame of scaleKeyArray) {
           var { x, y, z } = keyFrame.data_points[0];
-          outfileText += `,\n new Keyframe(${round2(keyFrame.time)
-            }f, KeyframeAnimations.scaleVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          outfileText += `,\n\t\tnew Keyframe(${keyFrame.time
+            }f, KeyframeAnimations.scaleVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f),\n\t\t\tAnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
       }
     }
-    outfileText += ".build();";
+    outfileText += ".build();"
   }
-  return outfileText;
+  return outfileText.replaceAll("66666666666","67").replaceAll("33333333333","34");
 }
 
-function round2(x) {
-  return Math.round((Number(x) + Number.EPSILON) * 100) / 100;
+function round2(n) {
+  return Math.round((Number(n) + Number.EPSILON) * 100) / 100;
 }

--- a/plugins/animation_to_java.js
+++ b/plugins/animation_to_java.js
@@ -7,7 +7,7 @@
     description:
       "Converts Blockbench animations to Java code for the new 1.19 keyframe system",
     icon: "fa-cube",
-    version: "1.1.1",
+    version: "1.1.2",
     variant: "both",
     about:
       "This plugin exports your blockbench animations as java code to be used for the new 1.19 keyframe system. Please note that this system does not support Molang or step interpolation",
@@ -39,15 +39,14 @@
 })();
 
 function generateFile() {
-  let outfileText = "";      
+  let outfileText = "";
 
   for (const animation of Animation.all) {
     outfileText += `\npublic static final AnimationDefinition ${animation.name
       .replaceAll(".", "_")
       .replace("animation_", "")
-      .toUpperCase()} = AnimationDefinition.Builder.withLength(${
-      animation.length
-    }f)`;
+      .toUpperCase()} = AnimationDefinition.Builder.withLength(${animation.length
+      }f)`;
     if (animation.loop === "loop") {
       outfileText += ".looping()";
     }
@@ -60,50 +59,47 @@ function generateFile() {
       let scaleKeyArray = [];
 
       if (boneAnimator.position.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}", new AnimationChannel(AnimationChannel.Targets.POSITION`;
-            //Sorts by time to ensure ordering
-            for (const keyFrame of boneAnimator.position) {
-              posKeyArray.push(keyFrame);
-            }
-            posKeyArray.sort((a, b) => a.time - b.time)
+        outfileText += `.addAnimation("${boneAnimator._name}",\n new AnimationChannel(AnimationChannel.Targets.POSITION`;
+        //Sorts by time to ensure ordering
+        for (const keyFrame of boneAnimator.position) {
+          posKeyArray.push(keyFrame);
+        }
+        posKeyArray.sort((a, b) => a.time - b.time)
 
         for (const keyFrame of posKeyArray) {
-          const { x, y, z } = keyFrame.data_points[0];
-          outfileText += `, new Keyframe(${
-            keyFrame.time
-          }f, KeyframeAnimations.posVec(${x}f, ${y}f, ${z}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          var { x, y, z } = keyFrame.data_points[0];
+          outfileText += `, \n new Keyframe(${round2(keyFrame.time)
+            }f, KeyframeAnimations.posVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
       }
       if (boneAnimator.rotation.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}", new AnimationChannel(AnimationChannel.Targets.ROTATION`;
-           //Sorts by time to ensure ordering
-           for (const keyFrame of boneAnimator.rotation) {
-            rotKeyArray.push(keyFrame);
-          }
-          rotKeyArray.sort((a, b) => a.time - b.time)
+        outfileText += `.addAnimation("${boneAnimator._name}",\n new AnimationChannel(AnimationChannel.Targets.ROTATION`;
+        //Sorts by time to ensure ordering
+        for (const keyFrame of boneAnimator.rotation) {
+          rotKeyArray.push(keyFrame);
+        }
+        rotKeyArray.sort((a, b) => a.time - b.time)
 
         for (const keyFrame of rotKeyArray) {
-          const { x, y, z } = keyFrame.data_points[0];
-          outfileText += `, new Keyframe(${
-            keyFrame.time
-          }f, KeyframeAnimations.degreeVec(${x}f, ${y}f, ${z}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          var { x, y, z } = keyFrame.data_points[0];
+          outfileText += `,\n new Keyframe(${round2(keyFrame.time)
+            }f, KeyframeAnimations.degreeVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
-      }        
+      }
       if (boneAnimator.scale.length) {
-        outfileText += `.addAnimation("${boneAnimator._name}", new AnimationChannel(AnimationChannel.Targets.SCALE`;
+        outfileText += `.addAnimation("${boneAnimator._name}", \n new AnimationChannel(AnimationChannel.Targets.SCALE`;
         //Sorts by time to ensure ordering
         for (const keyFrame of boneAnimator.scale) {
           scaleKeyArray.push(keyFrame);
         }
         scaleKeyArray.sort((a, b) => a.time - b.time)
-      
+
         for (const keyFrame of scaleKeyArray) {
-          const { x, y, z } = keyFrame.data_points[0];
-          outfileText += `, new Keyframe(${
-            keyFrame.time
-          }f, KeyframeAnimations.scaleVec(${x}f, ${y}f, ${z}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
+          var { x, y, z } = keyFrame.data_points[0];
+          outfileText += `,\n new Keyframe(${round2(keyFrame.time)
+            }f, KeyframeAnimations.scaleVec(${round2(x)}f, ${round2(y)}f, ${round2(z)}f), AnimationChannel.Interpolations.${keyFrame.interpolation.toUpperCase()})`;
         }
         outfileText += "))";
       }
@@ -111,4 +107,8 @@ function generateFile() {
     outfileText += ".build();";
   }
   return outfileText;
+}
+
+function round2(x) {
+  return Math.round((Number(x) + Number.EPSILON) * 100) / 100;
 }


### PR DESCRIPTION
Before this when exporting to a Java animation txt file, not only was each file line so long it would crash eclipse but it also had some weird line breaks meaning it couldn't be formatted or directly used without manual cleanup like this.
![image](https://user-images.githubusercontent.com/30220432/200384693-6579997b-2859-4da3-9f39-180ab5f54fba.png)
****
Ive added a round function to each float field that not only will reduce file size considerably but also fixes formatting so it can be directly copy and pasted without issue.
![image](https://user-images.githubusercontent.com/30220432/200384734-58fceaa6-27d1-4008-af4d-e1ab0c99d823.png)
