### PR TITLE
Add Highlight mod shape generator

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -723,5 +723,14 @@
 		"version": "1.0.0",
 		"variant": "both",
 		"tags": ["Exporter"]
+	},
+	"highlight_generator": {
+		"title": "Highlight Mod Shape Generator",
+		"icon": "fa-cube",
+		"author": "ThatGravyBoat",
+		"description": "Generates Shape JSONs for the Highlight mod. Mod can be found at: https://links.resourcefulbees.com/highlight",
+		"version": "1.0.0",
+		"variant": "both",
+		"tags": ["Minecraft: Java Edition"]
 	}
 }

--- a/plugins/highlight_generator.js
+++ b/plugins/highlight_generator.js
@@ -1,0 +1,86 @@
+(function(){
+    let button;
+
+    Plugin.register('highlight_generator', {
+        title: 'Highlight Mod Shape Generator',
+        author: 'ThatGravyBoat',
+        description: 'Generates Shape JSONs for the Highlight mod. Mod can be found at: https://links.resourcefulbees.com/highlight',
+        icon: 'fa-cube',
+        version: '1.0.0',
+        variant: 'both',
+        tags: ["Minecraft: Java Edition"],
+        onload(){
+            button = new Action("export_highlight", {
+                name : 'Export Highlight',
+                description : 'Exports Highlight mod shape JSON',
+                icon : 'fa-file-export',
+                click: function(){
+                    Blockbench.export({
+                        type : 'Highlight Shape Export',
+                        extensions: ['json'],
+                        savetype: 'text',
+                        content: generateFile()
+                    });
+                }
+            });
+
+            MenuBar.addAction(button, "file.export");
+        },
+        onunload(){
+            button.delete();
+        }
+    });
+
+})();
+
+function generateFile(){
+    let data = [];
+    for (let cube of Cube.all) {
+        const formattedLines = cube.getGlobalVertexPositions().map(point => point.map(value => value / 16.0));
+        const convertedVertices = [
+            [formattedLines[2], formattedLines[3], formattedLines[6], formattedLines[7]],
+            [formattedLines[0], formattedLines[1], formattedLines[4], formattedLines[5]]
+        ]
+
+        for (let convertedVertex of convertedVertices) {
+            for (let edge of createHorizontalEdges(convertedVertex)) {
+                let topFace = []
+                topFace.push(...edge[0])
+                topFace.push(...edge[1])
+                if (!data.includes(topFace)) {
+                    data.push(topFace)
+                }
+            }
+            data.push(null)
+        }
+
+        for (let edge of createVerticalEdges(convertedVertices[0], convertedVertices[1])) {
+            let topFace = []
+            topFace.push(...edge[0])
+            topFace.push(...edge[1])
+            if (!data.includes(topFace)) {
+                data.push(topFace)
+            }
+        }
+        data.push(null)
+    }
+    data.pop()
+    // The json is formatted below like this so its easier to read as each "section" will be seperated by a newline.
+    let output = `{\n    "lines": [\n`
+    for (let datum of data) {
+        if (datum == null) {
+            output += `\n`
+        } else {
+            output += `        [${datum[0]}, ${datum[1]}, ${datum[2]}, ${datum[3]}, ${datum[4]}, ${datum[5]}],\n`
+        }
+    }
+    return output.substr(0, output.length - 2) + `\n    \n}`;
+}
+
+function createHorizontalEdges(vertices) {
+    return [[vertices[2], vertices[3]], [vertices[2], vertices[1]], [vertices[1], vertices[0]], [vertices[3], vertices[0]]]
+}
+
+function createVerticalEdges(top, bottom) {
+    return [[bottom[3], top[3]], [bottom[2], top[2]], [bottom[1], top[1]], [bottom[0], top[0]]]
+}

--- a/plugins/highlight_generator.js
+++ b/plugins/highlight_generator.js
@@ -74,7 +74,7 @@ function generateFile(){
             output += `        [${datum[0]}, ${datum[1]}, ${datum[2]}, ${datum[3]}, ${datum[4]}, ${datum[5]}],\n`
         }
     }
-    return output.substr(0, output.length - 2) + `\n    \n}`;
+    return output.substr(0, output.length - 2) + `\n    ]\n}`;
 }
 
 function createHorizontalEdges(vertices) {

--- a/plugins/highlight_generator.js
+++ b/plugins/highlight_generator.js
@@ -31,19 +31,28 @@
         }
     });
 
-})();
+    function generateFile(){
+        let data = [];
+        for (let cube of Cube.all) {
+            const formattedLines = cube.getGlobalVertexPositions().map(point => point.map(value => value / 16.0));
+            const convertedVertices = [
+                [formattedLines[2], formattedLines[3], formattedLines[6], formattedLines[7]],
+                [formattedLines[0], formattedLines[1], formattedLines[4], formattedLines[5]]
+            ]
 
-function generateFile(){
-    let data = [];
-    for (let cube of Cube.all) {
-        const formattedLines = cube.getGlobalVertexPositions().map(point => point.map(value => value / 16.0));
-        const convertedVertices = [
-            [formattedLines[2], formattedLines[3], formattedLines[6], formattedLines[7]],
-            [formattedLines[0], formattedLines[1], formattedLines[4], formattedLines[5]]
-        ]
+            for (let convertedVertex of convertedVertices) {
+                for (let edge of createHorizontalEdges(convertedVertex)) {
+                    let topFace = []
+                    topFace.push(...edge[0])
+                    topFace.push(...edge[1])
+                    if (!data.includes(topFace)) {
+                        data.push(topFace)
+                    }
+                }
+                data.push(null)
+            }
 
-        for (let convertedVertex of convertedVertices) {
-            for (let edge of createHorizontalEdges(convertedVertex)) {
+            for (let edge of createVerticalEdges(convertedVertices[0], convertedVertices[1])) {
                 let topFace = []
                 topFace.push(...edge[0])
                 topFace.push(...edge[1])
@@ -53,34 +62,25 @@ function generateFile(){
             }
             data.push(null)
         }
-
-        for (let edge of createVerticalEdges(convertedVertices[0], convertedVertices[1])) {
-            let topFace = []
-            topFace.push(...edge[0])
-            topFace.push(...edge[1])
-            if (!data.includes(topFace)) {
-                data.push(topFace)
+        data.pop()
+        // The json is formatted below like this so its easier to read as each "section" will be seperated by a newline.
+        let output = `{\n    "lines": [\n`
+        for (let datum of data) {
+            if (datum == null) {
+                output += `\n`
+            } else {
+                output += `        [${datum[0]}, ${datum[1]}, ${datum[2]}, ${datum[3]}, ${datum[4]}, ${datum[5]}],\n`
             }
         }
-        data.push(null)
+        return output.substr(0, output.length - 2) + `\n    ]\n}`;
     }
-    data.pop()
-    // The json is formatted below like this so its easier to read as each "section" will be seperated by a newline.
-    let output = `{\n    "lines": [\n`
-    for (let datum of data) {
-        if (datum == null) {
-            output += `\n`
-        } else {
-            output += `        [${datum[0]}, ${datum[1]}, ${datum[2]}, ${datum[3]}, ${datum[4]}, ${datum[5]}],\n`
-        }
+
+    function createHorizontalEdges(vertices) {
+        return [[vertices[2], vertices[3]], [vertices[2], vertices[1]], [vertices[1], vertices[0]], [vertices[3], vertices[0]]]
     }
-    return output.substr(0, output.length - 2) + `\n    ]\n}`;
-}
 
-function createHorizontalEdges(vertices) {
-    return [[vertices[2], vertices[3]], [vertices[2], vertices[1]], [vertices[1], vertices[0]], [vertices[3], vertices[0]]]
-}
+    function createVerticalEdges(top, bottom) {
+        return [[bottom[3], top[3]], [bottom[2], top[2]], [bottom[1], top[1]], [bottom[0], top[0]]]
+    }
 
-function createVerticalEdges(top, bottom) {
-    return [[bottom[3], top[3]], [bottom[2], top[2]], [bottom[1], top[1]], [bottom[0], top[0]]]
-}
+})();


### PR DESCRIPTION

Overview:
---
This plugin supports exporting to the Highlight(Resourceful Lib) mod shape format, allowing for non axis-aligned visual bounding boxes for blocks.

The mod can be found here: https://links.resourcefulbees.com/highlight

---

I don't know what your policy is for mod support as you have a plugin for Geckolib, Highlight the mod itself (which is used to provide vanilla compat) is a bit small but the JSON API behind it which is in [Resourceful Lib](https://www.curseforge.com/minecraft/mc-mods/resourceful-lib) is a bit bigger.

