### PR TITLE
[Fix] Typos in sam3DJ description

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3,10 +3,10 @@
 		"title": "sam3DJ",
 		"author": "1Turtle",
     	"tags": ["Minecraft: Java Edition", "Format", "Exporter"],
-		"version": "1.0.0",
+		"version": "1.0.1",
     	"variant": "both",
-    	"description": "Generate 3D prints in MC (Java Edition) via .3DJ format within the CC-Peripherals mod!",
-		"about": "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **CC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a 'state_on' folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",
+    	"description": "Generate 3D prints in MC (Java Edition) via the .3DJ format within the SC-Peripherals mod!",
+        "about": "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **SC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a `state_on` folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",
 		"icon": "print"
 	},
 	"armor_stand_animator": {

--- a/plugins/sam3dj.js
+++ b/plugins/sam3dj.js
@@ -8,10 +8,10 @@
         title: 'sam3DJ',
         author: '1Turtle',
         tags: ['Minecraft: Java Edition', 'Format', 'Exporter'],
-        version: '1.0.0',
+        version: '1.0.1',
         variant: 'both',
-        description: 'Generate 3D prints in MC (Java Edition) via .3DJ format within the CC-Peripherals mod!',
-        about: "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **CC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a 'state_on' folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",
+        description: 'Generate 3D prints in MC (Java Edition) via the .3DJ format within the SC-Peripherals mod!',
+        about: "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **SC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a `state_on` folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",
         icon: 'print',
         onload() {
             MenuBar.addAction(btnExport, 'file.export');


### PR DESCRIPTION
This pull request is a small fix for sam3DJ.
I made a small but quiet important mistake in the about/description field.
The mod is called **S**C-Peripherals, and not **C**C-Peripherals..
The description also displayed the 'state_on' part weirdly. I *(hopefully)* fixed it by displaying it like this now: `state_on`.
The underscore was invisible before.