### PR TITLE
Explorer Plugin: fix navigateBackTo

### DIFF
--- a/plugins/explorer.js
+++ b/plugins/explorer.js
@@ -272,6 +272,7 @@ BBPlugin.register('explorer', {
 						if (!index) return;
 						let arr = this.path.split(/[/\\]+/)
 						arr = arr.slice(0, -Math.min(index, arr.length-2));
+						if (arr[0].length === 0) arr[0] = PathModule.sep;
 						this.goTo(PathModule.join(...arr));
 					},
 					createFile(event) {
@@ -366,7 +367,6 @@ BBPlugin.register('explorer', {
 							<div class="tool" @click="createFile($event)" title="New File"><i class="material-icons">note_add</i></div>
 						</div>
 						<ul class="list">
-							<li 
 							<li v-for="file in files" :key="file.path"
 								class="sidebar_explorer_file" :class="{selected: selected.includes(file.path), unsupported: file.icon.textContent == 'insert_drive_file'}"
 								@click="clickFile(file)" @dblclick="dblClickFile(file)" @contextmenu.stop="openContextMenu(file, $event)"


### PR DESCRIPTION
The navigation using the breadcrumbs in the explorer does not work (at least for me), because the navigateBackTo function joins the new path without a / at the start of the path, although the input path started with a /.
The fix may be kind of dirty, but works (tested on Linux and Windows).
This PR also fixes an unclosed `<li` tag