### PR TITLE
BBS model exporter: Fix keyframe exporter mishandling Effect keyframes

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -710,8 +710,8 @@
 		"title": "BBS model exporter",
 		"icon": "fa-file-export",
 		"author": "McHorse",
-		"description": "Adds a model exporter which allows to export models in BBS model format",
-		"version": "1.1.1",
+		"description": "Export model as a BBS (.bbs.json) model",
+		"version": "1.1.2",
 		"variant": "both",
 		"tags": ["Exporter"]
 	},

--- a/plugins.json
+++ b/plugins.json
@@ -710,7 +710,7 @@
 		"title": "BBS model exporter",
 		"icon": "fa-file-export",
 		"author": "McHorse",
-		"description": "Export model as a BBS (.bbs.json) model",
+		"description": "Adds a model exporter which allows to export models to BBS, a voxel-like engine/sandbox for creating video games, mini-games, and machinimas.",
 		"version": "1.1.2",
 		"variant": "both",
 		"tags": ["Exporter"]

--- a/plugins/bbs_exporter.js
+++ b/plugins/bbs_exporter.js
@@ -429,7 +429,7 @@
             button = new Action("bbs_exporter", {
                 name: "Export BBS model",
                 category: "file",
-                description: "Export model as a BBS (.bbs.json) model",
+                description: "Adds a model exporter which allows to export models to BBS, a voxel-like engine/sandbox for creating video games, mini-games, and machinimas.",
                 icon: "fa-file-export",
                 click() {
                     exportDialog.show();

--- a/plugins/bbs_exporter.js
+++ b/plugins/bbs_exporter.js
@@ -226,6 +226,11 @@
 
     function createAnimationKeyframes(g)
     {
+        if (!g)
+        {
+            return [];
+        }
+
         var keyframes = [];
 
         for (let i = 0; i < g.length; i++)
@@ -351,6 +356,11 @@
         remember: false,
         compile(options) {
             return autoStringify(compile());
+        },
+        fileName() {
+            var name = Project.name || "model";
+
+            return name.endsWith("bbs") ? name : name + ".bbs";
         }
     });
 
@@ -413,13 +423,13 @@
         author: "McHorse",
         description: "Adds a model exporter which allows to export models in BBS model format",
         icon: "fa-file-export",
-        version: "1.1.1",
+        version: "1.1.2",
         variant: "both",
         onload() {
             button = new Action("bbs_exporter", {
                 name: "Export BBS model",
                 category: "file",
-                description: "Export model as a BBS (.json) model",
+                description: "Export model as a BBS (.bbs.json) model",
                 icon: "fa-file-export",
                 click() {
                     exportDialog.show();

--- a/plugins/bbs_exporter.js
+++ b/plugins/bbs_exporter.js
@@ -421,7 +421,7 @@
     Plugin.register("bbs_exporter", {
         title: "BBS model exporter",
         author: "McHorse",
-        description: "Adds a model exporter which allows to export models in BBS model format",
+        description: "Adds a model exporter which allows to export models to BBS, a voxel-like engine/sandbox for creating video games, mini-games, and machinimas.",
         icon: "fa-file-export",
         version: "1.1.2",
         variant: "both",
@@ -429,7 +429,7 @@
             button = new Action("bbs_exporter", {
                 name: "Export BBS model",
                 category: "file",
-                description: "Adds a model exporter which allows to export models to BBS, a voxel-like engine/sandbox for creating video games, mini-games, and machinimas.",
+                description: "Export model as a BBS (.bbs.json) model",
                 icon: "fa-file-export",
                 click() {
                     exportDialog.show();


### PR DESCRIPTION
I didn't considered Effect keyframes, so this caused an error that doesn't allows exporting a model. I also added appending `.bbs` to the file name, because BBS expects its models to be have that extension (to avoid future configuration files that are just `.json`).