### PR TITLE
Add Cube Inverter, update MC Text Gen and Outline Creator

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -805,7 +805,7 @@
 		"author": "SirJain",
 		"icon": "swap_horiz",
 		"description": "Adds a button that inverts selected cube sizes.",
-		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the edit tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
+		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the `Tools` tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
 		"version": "1.0.0",
 		"min_version": "4.2.0",
 		"variant": "both"

--- a/plugins.json
+++ b/plugins.json
@@ -805,7 +805,7 @@
 		"author": "SirJain",
 		"icon": "swap_horiz",
 		"description": "Adds a button that inverts selected cube sizes.",
-		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the `Tools` tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
+		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the toolbar at the top of the screen (the one with the move, resize, and rotation tools) and click the `Invert Cubes` button. If you don't see the button, make sure to select some cubes. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
 		"version": "1.0.0",
 		"min_version": "4.2.0",
 		"variant": "both"

--- a/plugins.json
+++ b/plugins.json
@@ -754,7 +754,7 @@
 		"description": "Generates Minecraft-styled text in cubes.",
 		"about": "This plugin adds a button under the `Tools` menu that allows you to generate Minecraft-like text.\n## How to use\nTo use this plugin, go to `Tools > Generate Text`. Simply enter some text, configure your settings how you like, and press `Generate`!\n\nPlease report any bugs or suggestions you may have.",
 		"tags": ["Minecraft", "Font", "Generator"],
-		"version": "2.0.0",
+		"version": "2.0.1",
 		"min_version": "4.2.0",
 		"variant": "both"
 	},

--- a/plugins.json
+++ b/plugins.json
@@ -97,11 +97,11 @@
 	"outline_creator": {
 		"title": "Outline Creator",
 		"author": "Wither",
-		"description": "Creates stylistic outlines for cubes using negative scale values.",
-		"about": "Select an element you want to create an outline for, go to the `Tools` menu and click on the `Create Outline` option.\n<b>Note: This plugin only works on cubes!</b>",
+		"description": "Creates stylistic outlines for cubes and meshes using negative scale values.",
+		"about": "Select an element you want to create an outline for, go to the `Tools` menu and click on the `Create Outline` option.",
 		"icon": "crop_square",
-		"version": "1.0.3",
-		"min_version": "3.0.0",
+		"version": "1.1.0",
+		"min_version": "4.2.0",
 		"variant": "both"
 	},
 	"vox_importer": {

--- a/plugins.json
+++ b/plugins.json
@@ -799,5 +799,14 @@
 		"min_version": "4.0.0",
 		"await_loading": true,
 		"variant": "both"
+	},
+	"cube_inverter": {
+		"title": "Cube Inverter",
+		"author": "SirJain",
+		"icon": "swap_horiz",
+		"description": "Adds a button that inverts selected cube sizes.",
+		"version": "1.0.0",
+		"min_version": "4.2.0",
+		"variant": "both"
 	}
 }

--- a/plugins.json
+++ b/plugins.json
@@ -805,6 +805,7 @@
 		"author": "SirJain",
 		"icon": "swap_horiz",
 		"description": "Adds a button that inverts selected cube sizes.",
+		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the edit tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
 		"version": "1.0.0",
 		"min_version": "4.2.0",
 		"variant": "both"

--- a/plugins.json
+++ b/plugins.json
@@ -753,7 +753,7 @@
 		"author": "SirJain",
 		"description": "Generates Minecraft-styled text in cubes.",
 		"about": "This plugin adds a button under the `Tools` menu that allows you to generate Minecraft-like text.\n## How to use\nTo use this plugin, go to `Tools > Generate Text`. Simply enter some text, configure your settings how you like, and press `Generate`!\n\nPlease report any bugs or suggestions you may have.",
-		"tags": ["Minecraft", "Font", "Generator"],
+		"tags": ["Deprecated", "Minecraft", "Font"],
 		"version": "2.0.1",
 		"min_version": "4.2.0",
 		"variant": "both"

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -1,0 +1,174 @@
+(async function() {
+        let aboutAction, cubeInverterAction
+        const id = "cube_inverter"
+        const name = "Cube Inverter"
+        const icon = "swap_horiz"
+        const author = "SirJain"
+
+        // Used for about dialog
+        const links = {
+                website: "https://sirjain0.github.io/",
+                twitter: "https://twitter.com/SirJain2",
+                discord: "https://discord.gg/wM4CKTbFVN"
+        }
+
+        // Registers plugin data
+        Plugin.register(id, {
+                title: name,
+                icon,
+                author,
+                description: "Adds a button that inverts selected cube sizes.",
+                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the size values of the cube (located in edit mode) and click the `Invert Cubes` button located next to the Inflation value. The button is also keybinded with a default of `Shift + I`. You can add or remove the tool using the `Customize Toolbar` option.\n\nPlease report any bugs or suggestions you may have.",
+                version: "1.0.0",
+                min_version: "4.2.0",
+                variant: "both",
+                oninstall: () => showAbout(true),
+                onload() {
+                        addAbout()
+
+                        cubeInverterAction = new Action("cube_inverter_action", {
+                                name: "Invert Cubes",
+                                icon: icon,
+                                description: "Invert the values of all axes of selected cubes.",
+                                keybind: new Keybind({key: 'i', shift: true}),
+                                condition: () => Cube.selected.length,
+                                click: () => invertCubes()
+                        })
+
+                        Toolbars.element_size.add(cubeInverterAction)
+                },
+                onunload() {
+                        aboutAction.delete()
+                        cubeInverterAction.delete()
+                        MenuBar.removeAction(`help.about_plugins.about_${id}`)
+                        Blockbench.showQuickMessage("Uninstalled Cube Inverter plugin")
+                }
+        })
+
+        function invertCubes() {
+                Undo.initEdit({elements: Cube.selected, outliner: true});
+
+                for (const cube of Cube.selected) {
+
+                        // Handles size dimensions
+                        [cube.from, cube.to] = [cube.to, cube.from]
+
+                        // UV handling
+                        cube.faces.north.uv = cube.faces.south.uv
+                        cube.faces.south.uv = cube.faces.north.uv
+                        cube.faces.north.texture = cube.faces.south.texture 
+                        cube.faces.south.texture = cube.faces.north.texture
+                        cube.faces.north.cullface = cube.faces.south.cullface 
+                        cube.faces.south.cullface = cube.faces.north.cullface
+                        cube.faces.north.rotation += 180
+                        cube.faces.south.rotation += 180
+
+                        cube.faces.east.uv = cube.faces.west.uv
+                        cube.faces.west.uv = cube.faces.east.uv
+                        cube.faces.east.texture = cube.faces.west.texture 
+                        cube.faces.west.texture = cube.faces.east.texture
+                        cube.faces.east.cullface = cube.faces.west.cullface 
+                        cube.faces.west.cullface = cube.faces.east.cullface
+                        cube.faces.east.rotation += 180
+                        cube.faces.west.rotation += 180
+
+                        cube.faces.up.uv = cube.faces.down.uv
+                        cube.faces.down.uv = cube.faces.up.uv
+                        cube.faces.up.texture = cube.faces.down.texture 
+                        cube.faces.down.texture = cube.faces.up.texture
+                        cube.faces.up.cullface = cube.faces.down.cullface 
+                        cube.faces.down.cullface = cube.faces.up.cullface
+                        cube.faces.up.rotation += 180
+                        cube.faces.down.rotation += 180
+                }
+
+                Canvas.updateAll()
+                Undo.finishEdit("Inverted cube values", {elements: Cube.selected, outliner: true});
+        }
+
+        function addAbout() {
+                let about = MenuBar.menus.help.structure.find(e => e.id === "about_plugins")
+
+                if (!about) {
+                        about = new Action("about_plugins", {
+                                name: "About Plugins...",
+                                icon: "info",
+                                children: []
+                        })
+                        MenuBar.addAction(about, "help")
+                }
+
+                aboutAction = new Action(`about_${id}`, {
+                        name: `About ${name}...`,
+                        icon,
+                        click: () => showAbout()
+                })
+
+                about.children.push(aboutAction)
+        }
+
+        function showAbout(banner) {
+                const infoBox = new Dialog({
+                        id: "about",
+                        title: name,
+                        width: 780,
+                        buttons: [],
+                        lines: [`
+                                <style>
+                                        dialog#about .dialog_title {
+                                                padding-left: 0;
+                                                display: flex;
+                                                align-items: center;
+                                                gap: 10px;
+                                        }
+                                        dialog#about .dialog_content {
+                                                text-align: left!important;
+                                                margin: 0!important;
+                                        }
+                                        dialog#about .socials {
+                                                padding: 0!important;
+                                        }
+                                        dialog#about #banner {
+                                                background-color: var(--color-accent);
+                                                color: var(--color-accent_text);
+                                                width: 100%;
+                                                padding: 0 8px
+                                        }
+                                        dialog#about #content {
+                                                margin: 24px;
+                                        }
+                                </style>
+                                ${banner ? `<div id="banner">This window can be reopened at any time from <strong>Help > About Plugins > ${name}</strong></div>` : ""}
+                                <div id="content">
+                                        <h1 style="margin-top:-10px">${name}</h1>
+                                        <p>Adds a button that inverts selected cube sizes.</p>
+                                        <h4>Worth noting:</h4>
+                                        <p>- The plugin inverts each value of all the cubes selected - Positive to Negative or Negative to Positive.</p>
+                                        <p>- This plugin logically works on cubes - no meshes or other outliner elements.</p>
+                                        <p>- Like all other keybindings, the keybind tied to the 'Invert Cube' action can be changed in the settings.</p>
+                                        <h4>How to use:</h4>
+                                        <p>To use this plugin, press the <b>Invert Cubes</b> button which is located next to the Inflation number in the edit tab.</p>
+                                        <br>
+                                        <div class="socials">
+                                                <a href="${links["website"]}" class="open-in-browser">
+                                                        <i class="icon material-icons" style="color:#33E38E">language</i>
+                                                        <label>Website</label>
+                                                </a>
+                                                <a href="${links["discord"]}" class="open-in-browser">
+                                                        <i class="icon fab fa-discord" style="color:#727FFF"></i>
+                                                        <label>Discord Server</label>
+                                                </a>
+                                                <a href="${links["twitter"]}" class="open-in-browser">
+                                                        <i class="fa-brands fa-twitter" style="color:#1DA1F2"></i>
+                                                        <label>Twitter</label>
+                                                </a>
+                                        </div>
+                                </div>
+                        `]
+                }).show()
+                $("dialog#about .dialog_title").html(`
+                        <i class="icon material-icons">${icon}</i>
+                        ${name}
+                `)
+        }
+})()

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -60,8 +60,8 @@
                         cube.faces.south.texture = cube.faces.north.texture
                         cube.faces.north.cullface = cube.faces.south.cullface 
                         cube.faces.south.cullface = cube.faces.north.cullface
-                        cube.faces.north.rotation += 180
-                        cube.faces.south.rotation += 180
+                        cube.faces.north.rotation += (cube.faces.north.rotation + 180) % 360
+                        cube.faces.south.rotation += (cube.faces.south.rotation + 180) % 360
 
                         cube.faces.east.uv = cube.faces.west.uv
                         cube.faces.west.uv = cube.faces.east.uv
@@ -69,8 +69,8 @@
                         cube.faces.west.texture = cube.faces.east.texture
                         cube.faces.east.cullface = cube.faces.west.cullface 
                         cube.faces.west.cullface = cube.faces.east.cullface
-                        cube.faces.east.rotation += 180
-                        cube.faces.west.rotation += 180
+                        cube.faces.east.rotation += (cube.faces.east.rotation + 180) % 360
+                        cube.faces.west.rotation += (cube.faces.west.rotation + 180) % 360
 
                         cube.faces.up.uv = cube.faces.down.uv
                         cube.faces.down.uv = cube.faces.up.uv
@@ -78,8 +78,8 @@
                         cube.faces.down.texture = cube.faces.up.texture
                         cube.faces.up.cullface = cube.faces.down.cullface 
                         cube.faces.down.cullface = cube.faces.up.cullface
-                        cube.faces.up.rotation += 180
-                        cube.faces.down.rotation += 180
+                        cube.faces.up.rotation += (cube.faces.up.rotation + 180) % 360
+                        cube.faces.down.rotation += (cube.faces.down.rotation + 180) % 360
                 }
 
                 Canvas.updateAll()

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -18,7 +18,7 @@
                 icon,
                 author,
                 description: "Adds a button that inverts selected cube sizes.",
-                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the edit tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
+                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the `Tools` tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
                 version: "1.0.0",
                 min_version: "4.2.0",
                 variant: "both",
@@ -35,7 +35,7 @@
                                 click: () => invertCubes()
                         })
 
-                        MenuBar.addAction(cubeInverterAction, "edit");
+                        MenuBar.addAction(cubeInverterAction, "tools");
                 },
                 onunload() {
                         aboutAction.delete()

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -18,7 +18,7 @@
                 icon,
                 author,
                 description: "Adds a button that inverts selected cube sizes.",
-                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the size values of the cube (located in edit mode) and click the `Invert Cubes` button located next to the Inflation value. The button is also keybinded with a default of `Shift + I`. You can add or remove the tool using the `Customize Toolbar` option.\n\nPlease report any bugs or suggestions you may have.",
+                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the edit tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
                 version: "1.0.0",
                 min_version: "4.2.0",
                 variant: "both",
@@ -35,7 +35,7 @@
                                 click: () => invertCubes()
                         })
 
-                        Toolbars.element_size.add(cubeInverterAction)
+                        MenuBar.addAction(cubeInverterAction, "edit");
                 },
                 onunload() {
                         aboutAction.delete()

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -47,6 +47,7 @@
 
         function invertCubes() {
                 Undo.initEdit({elements: Cube.selected, outliner: true});
+                let invertedElements = [];
 
                 for (const cube of Cube.selected) {
 
@@ -80,9 +81,15 @@
                         cube.faces.down.cullface = cube.faces.up.cullface
                         cube.faces.up.rotation += (cube.faces.up.rotation + 180) % 360
                         cube.faces.down.rotation += (cube.faces.down.rotation + 180) % 360
+
+                        invertedElements.push(cube)
                 }
 
-                Canvas.updateAll()
+                Canvas.updateView({
+                    elements: invertedElements,
+                    element_aspects: {transform: true, geometry: true},
+                })
+
                 Undo.finishEdit("Inverted cube values", {elements: Cube.selected, outliner: true});
         }
 

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -47,7 +47,6 @@
 
         function invertCubes() {
                 Undo.initEdit({elements: Cube.selected, outliner: true});
-                let invertedElements = [];
 
                 for (const cube of Cube.selected) {
 
@@ -81,13 +80,11 @@
                         cube.faces.down.cullface = cube.faces.up.cullface
                         cube.faces.up.rotation += (cube.faces.up.rotation + 180) % 360
                         cube.faces.down.rotation += (cube.faces.down.rotation + 180) % 360
-
-                        invertedElements.push(cube)
                 }
 
                 Canvas.updateView({
-                    elements: invertedElements,
-                    element_aspects: {transform: true, geometry: true},
+                        elements: Cube.selected,
+                        element_aspects: {transform: true, geometry: true},
                 })
 
                 Undo.finishEdit("Inverted cube values", {elements: Cube.selected, outliner: true});

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -60,8 +60,8 @@
                         cube.faces.south.texture = cube.faces.north.texture
                         cube.faces.north.cullface = cube.faces.south.cullface 
                         cube.faces.south.cullface = cube.faces.north.cullface
-                        cube.faces.north.rotation += (cube.faces.north.rotation + 180) % 360
-                        cube.faces.south.rotation += (cube.faces.south.rotation + 180) % 360
+                        cube.faces.north.rotation = (cube.faces.north.rotation + 180) % 360
+                        cube.faces.south.rotation = (cube.faces.south.rotation + 180) % 360
 
                         cube.faces.east.uv = cube.faces.west.uv
                         cube.faces.west.uv = cube.faces.east.uv
@@ -69,8 +69,8 @@
                         cube.faces.west.texture = cube.faces.east.texture
                         cube.faces.east.cullface = cube.faces.west.cullface 
                         cube.faces.west.cullface = cube.faces.east.cullface
-                        cube.faces.east.rotation += (cube.faces.east.rotation + 180) % 360
-                        cube.faces.west.rotation += (cube.faces.west.rotation + 180) % 360
+                        cube.faces.east.rotation = (cube.faces.east.rotation + 180) % 360
+                        cube.faces.west.rotation = (cube.faces.west.rotation + 180) % 360
 
                         cube.faces.up.uv = cube.faces.down.uv
                         cube.faces.down.uv = cube.faces.up.uv
@@ -78,8 +78,8 @@
                         cube.faces.down.texture = cube.faces.up.texture
                         cube.faces.up.cullface = cube.faces.down.cullface 
                         cube.faces.down.cullface = cube.faces.up.cullface
-                        cube.faces.up.rotation += (cube.faces.up.rotation + 180) % 360
-                        cube.faces.down.rotation += (cube.faces.down.rotation + 180) % 360
+                        cube.faces.up.rotation = (cube.faces.up.rotation + 180) % 360
+                        cube.faces.down.rotation = (cube.faces.down.rotation + 180) % 360
                 }
 
                 Canvas.updateView({

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -18,7 +18,7 @@
                 icon,
                 author,
                 description: "Adds a button that inverts selected cube sizes.",
-                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the `Tools` tab at the top of the screen and click the `Invert Cubes` button. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
+                about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the toolbar at the top of the screen (the one with the move, resize, and rotation tools) and click the `Invert Cubes` button. If you don't see the button, make sure to select some cubes. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
                 version: "1.0.0",
                 min_version: "4.2.0",
                 variant: "both",
@@ -35,7 +35,7 @@
                                 click: () => invertCubes()
                         })
 
-                        MenuBar.addAction(cubeInverterAction, "tools");
+                        Toolbars.main_tools.add(cubeInverterAction);
                 },
                 onunload() {
                         aboutAction.delete()

--- a/plugins/mc_text_generator.js
+++ b/plugins/mc_text_generator.js
@@ -557,6 +557,15 @@
                                     [0, 0, 0, 2, 2, formData.depth]
                                 ]
                             },
+                            "/": {
+                                width: 6,
+                                cubes: [
+                                    [0, 0, 0, 3, 2, formData.depth],
+                                    [1, 2, 0, 4, 4, formData.depth],
+                                    [2, 4, 0, 5, 6, formData.depth],
+                                    [3, 6, 0, 6, 8, formData.depth],
+                                ]
+                            },
                             " ": {
                                 width: formData.wordSpace,
                                 cubes: []

--- a/plugins/mc_text_generator.js
+++ b/plugins/mc_text_generator.js
@@ -72,8 +72,7 @@
                         label: "Depth",
                         type: "number",
                         min: 0,
-                        value: 2,
-                        max: 8,
+                        value: 4,
                         description: "The thickness of the letters. If 0, the letters will appear flat."
                     },
                     rotation: {
@@ -113,7 +112,7 @@
                     if (formData.input == "") {
                         Blockbench.showMessageBox({
                             title: "No valid text",
-                            message: "Make sure you don't leave the field blank."
+                            message: "Make sure you don't leave the text field blank."
                         })
 
                         generateTextDialog.hide()
@@ -652,14 +651,6 @@
                         formData.bedrockCheckbox == true && 
                         (textLength - formData.letterSpace >= 30 || 9*numLines >= 30)
                     ) showRestrictionWarning("`30x30x30`")
-
-                    // Check if user wanted to generate a layer but the depth was not 0
-                    else if (formData.generateLayer == true && formData.depth !== 0) {
-                        Blockbench.showMessageBox({
-                            title: "Incompatible settings",
-                            message: "If you want to generate a layer, please make sure the 'depth' field is 0."
-                        })
-                    }
                 }
             })
 

--- a/plugins/mc_text_generator.js
+++ b/plugins/mc_text_generator.js
@@ -25,7 +25,7 @@
         description: "Generates Minecraft-styled text in cubes.",
         about: "This plugin adds a button under the `Tools` menu that allows you to generate Minecraft-like text.\n## How to use\nTo use this plugin, go to `Tools > Generate Text`. Simply enter some text, configure your settings how you like, and press `Generate`!\n\nPlease report any bugs or suggestions you may have.",
         tags: ["Minecraft", "Font", "Generator"],
-        version: "2.0.0",
+        version: "2.0.1",
         min_version: "4.2.0",
         variant: "both",
 
@@ -51,7 +51,7 @@
                         type: "text",
                         full_width: true,
                         value: "",
-                        description: "Blockbench will take this and generate 3D text."
+                        description: "The text that will be converted into 3D geometry."
                     },
                     divider: "_",
                     letterSpace: {
@@ -59,7 +59,7 @@
                         type: "number",
                         min: 0,
                         value: 0.3,
-                        description: "The amount of space between letters."
+                        description: "The amount of space between each letter."
                     },
                     wordSpace: {
                         label: "Word Spacing",
@@ -83,13 +83,14 @@
                         value: 0,
                         max: 45,
                         step: 22.5,
-                        description: "The rotation of the cubes of the text."
+                        description: "The rotation of the text."
                     },
                     generateLayer: {
                         label: "Generate Layer",
                         type: "checkbox",
                         value: false,
-                        description: "Generates a second layer to the text which can be used for stuff like dropshadows. Note: Your depth field needs to be 0 in order for the setting to work."
+                        condition: formData => formData.depth === 0,
+                        description: "Generates a second layer to the text which can be used for stuff like dropshadows."
                     },
                     checkboxSpacer: "_",
                     javaCheckbox: {

--- a/plugins/mc_text_generator.js
+++ b/plugins/mc_text_generator.js
@@ -24,7 +24,7 @@
         author,
         description: "Generates Minecraft-styled text in cubes.",
         about: "This plugin adds a button under the `Tools` menu that allows you to generate Minecraft-like text.\n## How to use\nTo use this plugin, go to `Tools > Generate Text`. Simply enter some text, configure your settings how you like, and press `Generate`!\n\nPlease report any bugs or suggestions you may have.",
-        tags: ["Minecraft", "Font", "Generator"],
+        tags: ["Deprecated", "Minecraft", "Font"],
         version: "2.0.1",
         min_version: "4.2.0",
         variant: "both",

--- a/plugins/mc_text_generator.js
+++ b/plugins/mc_text_generator.js
@@ -296,6 +296,18 @@
                                     [0, 5, 0, 2, 6, formData.depth],
                                 ]
                             },
+                            "$": {
+                                width: 5,
+                                cubes: [
+                                    [0, 0, 0, 5, 2, formData.depth],
+                                    [0, 3, 0, 5, 5, formData.depth],
+                                    [0, 6, 0, 5, 8, formData.depth],
+                                    [1.5, 8, 0, 3.5, 9, formData.depth],
+                                    [1.5, -1, 0, 3.5, 0, formData.depth],
+                                    [3, 2, 0, 5, 3, formData.depth],
+                                    [0, 5, 0, 2, 6, formData.depth],
+                                ]
+                            },
                             t: {
                                 width: 5,
                                 cubes: [

--- a/plugins/outline_creator.js
+++ b/plugins/outline_creator.js
@@ -49,7 +49,6 @@ Plugin.register('outline_creator', {
 
 function createOutline(outline_thickness) {
     Undo.initEdit({elements: Outliner.elements, outliner: true});
-    let newElements = [];
 
     // Cube handling
     for (const element of Cube.selected) {
@@ -98,8 +97,6 @@ function createOutline(outline_thickness) {
                 }
             }
         }).init();
-
-        newElements.push(outline);
     }
 
     // Mesh handling
@@ -119,12 +116,10 @@ function createOutline(outline_thickness) {
         mesh.resize(outline_thickness, 1, false, false, true);
         mesh.resize(outline_thickness * 2, 2, false, false, true);
         mesh.name = mesh.name + "_outline";
-        
-        newElements.push(mesh);
     }
 
     Canvas.updateView({
-	elements: newElements,
+	elements: selected,
 	element_aspects: {transform: true, geometry: true},
     })
 

--- a/plugins/outline_creator.js
+++ b/plugins/outline_creator.js
@@ -49,6 +49,7 @@ Plugin.register('outline_creator', {
 
 function createOutline(outline_thickness) {
     Undo.initEdit({elements: Outliner.elements, outliner: true});
+    let newElements = [];
 
     // Cube handling
     for (const element of Cube.selected) {
@@ -97,6 +98,8 @@ function createOutline(outline_thickness) {
                 }
             }
         }).init();
+
+        newElements.push(outline);
     }
 
     // Mesh handling
@@ -116,9 +119,15 @@ function createOutline(outline_thickness) {
         mesh.resize(outline_thickness, 1, false, false, true);
         mesh.resize(outline_thickness * 2, 2, false, false, true);
         mesh.name = mesh.name + "_outline";
+        
+        newElements.push(mesh);
     }
 
-    Canvas.updateAll();
+    Canvas.updateView({
+		elements: newElements,
+		element_aspects: {transform: true, geometry: true},
+	})
+
     Undo.finishEdit('Created outlines');
 }
 

--- a/plugins/outline_creator.js
+++ b/plugins/outline_creator.js
@@ -124,9 +124,9 @@ function createOutline(outline_thickness) {
     }
 
     Canvas.updateView({
-		elements: newElements,
-		element_aspects: {transform: true, geometry: true},
-	})
+	elements: newElements,
+	element_aspects: {transform: true, geometry: true},
+    })
 
     Undo.finishEdit('Created outlines');
 }


### PR DESCRIPTION
# Cube Inverter
A simple plugin that inverts cubes with a click of the button.

There are many cases in which inverted cubes are useful (besides outlines), but making them is not too convenient as of now. Also, UVs will get messed up, which requires manual fixing. This plugin fixes that.

To use this plugin, press the button that appears in the size fields of the cubes (located next to the inflation box). The action is also keybinded for extra convenience.

# MC Text Generator
**Changelog:**
- Reword some incorrect or vague descriptions for some of the text settings
- Make layer setting only appear when the depth setting is 0
- Got rid of max limit for depth of characters
- Changed default thickness of characters
- Reworded the empty text field warning's description
- Added new characters: `$`, `/`
- Mark plugin as deprecated

# Outline Creator
**Changelog:**
- Added support for meshes