### PR TITLE
Fix VoxelShape generator plugin's incorrect plugin meta

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -453,10 +453,10 @@
 		"variant": "both"
 	},
 	"voxel_shape_generator": {
-		"title": "Voxel Shape Generator for MCP and Mojang Mappings",
+		"title": "VoxelShape Generators",
 		"icon": "fa-cubes",
 		"author": "Spectre0987",
-		"description": "Exports models as Voxel Shape code for Mojang or MCP mappings",
+		"description": "Generates Voxel Shapes (Supports Mojang Mappings and MCP)",
 		"version": "0.1.0",
 		"variant": "both",
 		"tags": ["Minecraft: Java Edition"]

--- a/plugins/voxel_shape_generator.js
+++ b/plugins/voxel_shape_generator.js
@@ -8,7 +8,7 @@
         author: 'Spectre0987',
         description: 'Generates Voxel Shapes (Supports Mojang Mappings and MCP)',
         icon: 'bar_chart',
-        version: '0.0.1',
+        version: '0.1.0',
         variant: 'both',
         tags: ["Minecraft: Java Edition"],
         onload(){


### PR DESCRIPTION
This PR doesn't change any code, simply matches the plugins.json file with the plugin file data