### PR TITLE
Updated Figura Model Format plugin to 0.1.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -837,7 +837,7 @@
 		"title": "Figura Model Format",
 		"author": "Katt (KitCat962)",
 		"icon": "icon.svg",
-		"description": "Create models for the Figura mod without unusable Blockbench features getting in the way.",
+		"description": "Create models for the Figura mod in a custom format that optimizes Blockbench to work with Figura models.",
 		"tags": ["Minecraft: Java Edition", "Figura"],
 		"version": "0.1.1",
 		"min_version": "4.8.0",

--- a/plugins.json
+++ b/plugins.json
@@ -836,12 +836,13 @@
 	"figura_format": {
 		"title": "Figura Model Format",
 		"author": "Katt (KitCat962)",
-		"icon": "change_history",
-		"description": "Adds a project format used for the Figura mod that removes features that Figura does not support and makes minor changes to clarify weird Figura behavior.",
+		"icon": "icon.svg",
+		"description": "Create models for the Figura mod without unusable Blockbench features getting in the way.",
 		"tags": ["Minecraft: Java Edition", "Figura"],
-		"version": "0.1.0",
-		"min_version": "4.7.0",
+		"version": "0.1.1",
+		"min_version": "4.8.0",
 		"variant": "both",
-		"await_loading": true
+		"await_loading": true,
+		"creation_date": "2023-07-22"
 	}
 }

--- a/plugins/figura_format/about.md
+++ b/plugins/figura_format/about.md
@@ -1,0 +1,24 @@
+Figura uses Blockbench for it's modeling, but some features of Blockbench will not be parsed by Figura.
+
+This Plugin adds a Project Format that will remove the following features from Blockbench:
+* Animated Textures
+* Model Identifier
+* Locators (Figura does not load them, and IK is not supported)
+* Group Name Limitations (Duplicate names and arbitrary characters are now allowed)
+* Molang Errors (Figura uses Lua in keyframes)
+* Texture Render Mode (Figura uses a more advanced system for emissive textures)
+* Particle and Sound keyframes
+
+The Plugin makes the following changes to improve clarity:
+* New Animations will be named `new` instead of the confusing name `animation.model.new`
+* Instruction keyframes have been renamed to Lua Script keyframes
+* The Anim Time Update property has been renamed to Start Offset, as that is how that property is used in Figura
+* Override has been renamed to Override Vanilla Animations
+* The Export Animations action has been removed
+
+Additionally, the Figura Project Format adds these features:
+* The "Match Project UV with Texture Size" Toggle under Tools, which will automatically set the Project UV to match the current texture to prevent the texture behaving weird in the preview (Not available with BoxUV)
+* The "Cycle Face Vertices action", which will allow you to change the triangulation of non-flat faces (You may need to use this multiple times, and/or invert the face for correct normals)
+
+<i style="pointer-events: none;color: black;opacity: 0.1;font-size: 700px;height: 614px;width: 584px;position: absolute;bottom: 0;right: 0;
+overflow: hidden;max-width: unset;" class="material-icons">change_history</i>

--- a/plugins/figura_format/figura_format.js
+++ b/plugins/figura_format/figura_format.js
@@ -52,7 +52,7 @@
 		title: "Figura Model Format",
 		author: "Katt (KitCat962)",
 		icon: "icon.svg",
-		description: "Create models for the Figura mod without unusable Blockbench features getting in the way.",
+		description: "Create models for the Figura mod in a custom format that optimizes Blockbench to work with Figura models.",
 		tags: ["Minecraft: Java Edition", "Figura"],
 		version: "0.1.1",
 		min_version: "4.8.0",

--- a/plugins/figura_format/figura_format.js
+++ b/plugins/figura_format/figura_format.js
@@ -49,50 +49,23 @@
 	}
 
 	BBPlugin.register('figura_format', {
-		title: 'Figura Model Format',
-		author: 'Katt (KitCat962)',
-		icon: 'change_history',
-		description: "Adds a project format used for the Figura mod that removes features that Figura does not support and makes minor changes to clarify weird Figura behavior.",
-		tags: ['Minecraft: Java Edition', 'Figura'],
-		version: '0.1.0',
-		min_version: '4.7.0',
-		variant: 'both',
+		title: "Figura Model Format",
+		author: "Katt (KitCat962)",
+		icon: "icon.svg",
+		description: "Create models for the Figura mod without unusable Blockbench features getting in the way.",
+		tags: ["Minecraft: Java Edition", "Figura"],
+		version: "0.1.1",
+		min_version: "4.8.0",
+		variant: "both",
 		await_loading: true,
+		creation_date: "2023-07-22",
 		onload() {
 			let callback
+			let particle = EffectAnimator.prototype.channels.particle, sound = EffectAnimator.prototype.channels.sound
 			format = new ModelFormat('figura', {
 				icon: 'change_history',
-				name: 'Figura',
+				name: 'Figura Model',
 				description: 'Model for the Figura mod.',
-				format_page: {
-					content: [
-						{
-							text:
-								`Figura uses Blockbench for it's modeling, but some features of Blockbench will not be parsed by Figura.
-						
-						This Plugin adds a Project Format that will remove the following features from Blockbench:
-						* Animated Textures (Figura parses them as normal textures)
-						* Model Identifier (What even is this anyways? Regardless, Figura doesnt use it)
-						* Locators (Figura does not load them, and IK is not supported)
-						* Group Name Limitations (Duplicate names and arbitrary characters are now allowed)
-						* Molang Errors (Figura uses lua, not molang)
-						* Texture Render Mode (Figura uses a more advanced system for emissive textures)
-						
-						The Plugin makes the following changes to improve clarity:
-						* Particle and Sound keyframes have been renamed to \`"N/A"\` as they are not used by Figura
-						* New Animations will be named \`new\` instead of the confusing name \`animation.model.new\`
-						* Instruction keyframes have been renamed to Lua Script keyframes
-						* The Anim Time Update property has been renamed to Start Offset, as that is how that property is used in Figura
-						* Override has been renamed to Override Vanilla Animations
-						* The Export Animations action has been removed
-						
-						Additionally, the Figura Project Format adds these features:
-						* The "Match Project UV with Texture Size" Toggle under Tools, which will automatically set the Project UV to match the current texture to prevent the texture behaving weird in the preview (Not available with BoxUV)
-						* The "Cycle Face Vertices action", which will allow you to change the triangulation of non-flat faces (You may need to use this multiple times, and/or invert the face for correct normals)`
-									.replace(/\t+/g, '')
-						}
-					]
-				},
 				category: 'low_poly',
 				target: ['Figura'],
 				show_on_start_screen: true,
@@ -131,24 +104,20 @@
 					Language.addTranslations('en', {
 						['menu.animation.anim_time_update']: "Start Offset",
 						['menu.animation.override']: "Override Vanilla Animations",
-						['timeline.particle']: "N/A",
-						['timeline.sound']: "N/A",
-						['timeline.timeline']: "Lua Script",
 					})
-					for (const [type, data] of Object.entries(EffectAnimator.prototype.channels))
-						data.name = tl(`timeline.${type}`)
+					delete EffectAnimator.prototype.channels.particle
+					delete EffectAnimator.prototype.channels.sound
+					EffectAnimator.prototype.channels.timeline.name = "Lua Script"
 				},
 				onDeactivation() {
 					callback.delete()
 					Language.addTranslations('en', {
 						['menu.animation.anim_time_update']: "Anim Time Update",
 						['menu.animation.override']: "Override",
-						['timeline.particle']: "Particle",
-						['timeline.sound']: "Sound",
-						['timeline.timeline']: "Instructions",
 					})
-					for (const [type, data] of Object.entries(EffectAnimator.prototype.channels))
-						data.name = tl(`timeline.${type}`)
+					EffectAnimator.prototype.channels.particle = particle
+					EffectAnimator.prototype.channels.sound = sound
+					EffectAnimator.prototype.channels.timeline.name = tl('timeline.timeline')
 				}
 			})
 
@@ -205,6 +174,12 @@
 			Dialog.prototype.build = function () {
 				if (Format === format && this.id == 'texture_edit') delete this.form.render_mode
 				DialogBuild.call(this)
+			}
+
+			let displayFrame = EffectAnimator.prototype.displayFrame
+			EffectAnimator.prototype.displayFrame = function(){
+				if (Format === format) return
+				displayFrame.call(this)
 			}
 		},
 		onunload() {

--- a/plugins/figura_format/icon.svg
+++ b/plugins/figura_format/icon.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg viewBox="0 0 203.2 203.2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <defs>
+    <linearGradient id="linearGradient56" x1="17.571072" y1="191.51862" x2="55.244778" y2="232.12518" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1, 0, 0, 1, 0, 0)" xlink:href="#linearGradient54"/>
+    <linearGradient id="linearGradient54">
+      <stop style="stop-opacity: 0.498542;" offset="0" id="stop55"/>
+      <stop style="stop-color:#000000;stop-opacity:0;" offset="1" id="stop56"/>
+    </linearGradient>
+  </defs>
+  <g id="layer1" transform="matrix(1, 0, 0, 1, 65.37128448486328, -111.62109375)">
+    <ellipse style="fill: rgb(8, 141, 211); stroke-width: 0.264583; fill-opacity: 1;" id="path1" cx="36.228714" cy="213.2211" rx="101.6" ry="101.80915" transform="translate(1.4583333e-7)"/>
+    <path style="stroke: rgb(255, 255, 255); stroke-width: 13; stroke-linejoin: round; stroke-dasharray: none; stroke-opacity: 1; fill: none;" d="M 36.229 154.203 L -12.205 251.072 L 84.663 251.072 L 36.229 154.203 Z" id="path2"/>
+    <path style="fill: url(#linearGradient56); fill-opacity: 1; stroke: rgb(255, 255, 255); stroke-width: 13; stroke-dasharray: none; stroke-opacity: 1; stroke-linejoin: round; visibility: hidden;" d="M 36.229 154.203 L -12.205 251.072 L 84.663 251.072 L 36.229 154.203 Z" id="path56"/>
+  </g>
+</svg>


### PR DESCRIPTION
Minor update changing the Project Type's name from "Figura" to "Figura Model" (community suggestion) and fully removed Particle and Sound keyframes instead of the rename patch job.

Additionally, the plugin has moved to the 4.8.0 plugin format

Currently I am assuming that "instructions no longer need to be stored in the plugin meta data" stated in the Blockbench Discord in the "4.8 API changes for plugin creators" post means that I do not need an `about` field in `plugins.json` for my plugin, as `about.md` will be used in it's stead for versions 4.8.0 and above. I am also assuming that plugins that have already updated to 4.8.0 only have the `about` field because of compatibility with 4.7.0. 
If these assumptions are incorrect at all, please let me know before merging and I'll fix it.