### PR TITLE
Fix text overflowing codeblock for azurelib_utils about.md

### DIFF
--- a/plugins/azurelib_utils/about.md
+++ b/plugins/azurelib_utils/about.md
@@ -30,3 +30,8 @@ dependencies {
         implementation fg.deobf('mod.azure.azurelib:azurelib-neo-MCVERSION:MODVERSION')
 }
 ```
+<style>
+  #plugin_browser_page pre {
+    overflow-x: auto;
+  }
+</style>


### PR DESCRIPTION
Fixes a small issue where in azurelib_utils the text was overflowing the codeblock in the about.md

Pinging @AzureDoom to let you know about this PR