### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/plugins/tint_preview.js
+++ b/plugins/tint_preview.js
@@ -226,7 +226,7 @@ var blockColorOptions = {
 	'water_wooded_badlands': 'Water (Wooded Badlands)'
 }
 
-// Color values sourced from https://minecraft.fandom.com/wiki/Block_colors
+// Color values sourced from https://minecraft.wiki/w/Block_colors
 var blockColorValues = {
 	'foilage_badlands': '#9e814d',
 	'foilage_bamboo_jungle': '#30bb0b',


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom.