### PR TITLE
Improve VoxelShape Fabric Generator exporter

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -482,7 +482,7 @@
 		"icon": "bar_chart",
 		"author": "CyberStefNef",
 		"description": "Generates Voxel Shapes for Fabric",
-		"version": "0.0.1",
+		"version": "1.0.0",
 		"variant": "both",
 		"tags": ["Minecraft: Java Edition"]
 	},

--- a/plugins/voxel_shape_fabric_generator.js
+++ b/plugins/voxel_shape_fabric_generator.js
@@ -8,7 +8,7 @@
     author: "CyberStefNef",
     description: "Generates Voxel Shapes for Fabric",
     icon: "bar_chart",
-    version: "0.0.1",
+    version: "1.0.0",
     variant: "both",
     tags: ["Minecraft: Java Edition"],
     onload() {
@@ -35,19 +35,25 @@
   });
 
   function generateFabricFile(centered) {
-    var data =
-      "public VoxelShape makeShape(){\n\tVoxelShape shape = VoxelShapes.empty();\n";
+    var data = "public static VoxelShape makeShape() {\n\treturn ";
 
-    for (var i = 0; i < Cube.all.length; ++i) {
-      var cube = Cube.all[i];
-
-      data += "\tshape = VoxelShapes.union(shape, VoxelShapes.cuboid("
-        .concat(formatVec3(cube.from, centered))
-        .concat(", ")
-        .concat(formatVec3(cube.to, centered))
-        .concat("));\n");
+    if (Cube.all.length < 1) {
+      data += "VoxelShapes.empty()";
+    } else {
+      data += "VoxelShapes.union(\n";
+      for (var i = 0; i < Cube.all.length; ++i) {
+        if (i > 0) data += ",\n";
+        const cube = Cube.all[i];
+        data += "\t\tVoxelShapes.cuboid("
+            .concat(formatVec3(cube.from, centered))
+            .concat(", ")
+            .concat(formatVec3(cube.to, centered))
+            .concat(")");
+      }
+      data += "\n\t)";
     }
-    data += "\n\treturn shape;\n}";
+
+    data += ";\n}";
     return data;
   }
 


### PR DESCRIPTION
Improves the code generated by the **VoxelShape Fabric Generator** plugin by merging all individual shapes into a single one.

Old generated code:
```java
public VoxelShape makeShape(){
	VoxelShape shape = VoxelShapes.empty();
	shape = VoxelShapes.union(shape, VoxelShapes.cuboid(0.1875, 0, 0.375, 0.8125, 0.8125, 0.875));
	shape = VoxelShapes.union(shape, VoxelShapes.cuboid(0.25, 0, 0.25, 0.75, 0.3125, 0.375));
	shape = VoxelShapes.union(shape, VoxelShapes.cuboid(0.125, 0, 0.4375, 0.1875, 0.4375, 0.8125));
	shape = VoxelShapes.union(shape, VoxelShapes.cuboid(0.8125, 0, 0.4375, 0.875, 0.4375, 0.8125));

	return shape;
}
```

New generated code:
```java
public static VoxelShape makeShape() {
	return VoxelShapes.union(
		VoxelShapes.cuboid(0.1875, 0, 0.375, 0.8125, 0.8125, 0.875),
		VoxelShapes.cuboid(0.25, 0, 0.25, 0.75, 0.3125, 0.375),
		VoxelShapes.cuboid(0.125, 0, 0.4375, 0.1875, 0.4375, 0.8125),
		VoxelShapes.cuboid(0.8125, 0, 0.4375, 0.875, 0.4375, 0.8125)
	);
}
```