### PR TITLE
Fixed bug with UVs not being inverted properly since the 4.9 update

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -60,7 +60,7 @@
 		"icon": "flip_to_back",
 		"description": "Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in Minecraft: Java Edition.",
 		"tags": ["Minecraft: Java Edition"],
-		"version": "1.0.0",
+		"version": "1.0.1",
 		"variant": "both"
 	},
 	"optimize": {

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -8,7 +8,7 @@
 		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
         tags: ["Minecraft: Java Edition"],
 		icon: 'flip_to_back',
-		version: '1.0.0',
+		version: '1.0.1',
 		variant: 'both',
 		onload() {
 			cube_action = new Action({

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -25,7 +25,7 @@
 					Undo.initEdit({elements:[]});
 					let cubes = [];
 					Cube.selected.forEach((cube) => {
-						const new_cube = new Cube({...cube}).init();
+						const new_cube = cube.duplicate();
 						new_cube.name = new_cube.name + " inverted";
 						if (cube.parent !== "root") {
 							new_cube.addTo(cube.parent);


### PR DESCRIPTION
In the old version it created an inverted cube, but the UV was the topleft-most pixel in the texture and no texture was assigned. 
By duplicating the cube and then inverting that problem is resolved (instead of initializing a new one with the original one's data).