### PR TITLE
Add ${header} to 1.17+ export in Fabric Modded Entity Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -369,7 +369,7 @@
 		"icon": "icon-format_java",
 		"description": "Plugin for exporting Modded Entities using Fabric/Yarn Sourcemap",
 		"tags": ["Minecraft: Java Edition"],
-		"version": "0.2.1",
+		"version": "0.2.2",
 		"min_version": "3.6.6",
 		"variant": "both"
 	},

--- a/plugins/modded_entity_fabric.js
+++ b/plugins/modded_entity_fabric.js
@@ -136,6 +136,9 @@ function setTemplate() {
 			`// Made with Blockbench %(bb_version)
 			// Exported for Minecraft version 1.17+ for Yarn
 			// Paste this class into your mod and generate all required imports
+
+			${header}
+   
 			public class %(identifier) extends EntityModel<${entity}> {
 				%(fields)
 				public %(identifier)(ModelPart root) {


### PR DESCRIPTION
While the `Fabric 1.14` and `Fabric 1.15-1.16` exporters added the `${header}` variable to the exported file, the `Fabric 1.17+` did not. This PR addresses this issue.