### PR TITLE
Add seat options to sam3dj plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -3,7 +3,7 @@
 		"title": "sam3DJ",
 		"author": "1Turtle",
 		"tags": ["Minecraft: Java Edition", "Format", "Exporter"],
-		"version": "1.0.3",
+		"version": "1.1.0",
 		"variant": "both",
 		"description": "Generate 3D prints in MC (Java Edition) via the .3DJ format within the SC-Peripherals mod!",
 		"about": "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **SC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a `state_on` folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",

--- a/plugins/sam3dj.js
+++ b/plugins/sam3dj.js
@@ -10,7 +10,7 @@
         title: 'sam3DJ',
         author: '1Turtle',
         tags: ['Minecraft: Java Edition', 'Format', 'Exporter'],
-        version: '1.0.3',
+        version: '1.0.4',
         variant: 'both',
         description: 'Generate 3D prints in MC (Java Edition) via the .3DJ format within the SC-Peripherals mod!',
         about: "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **SC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a `state_on` folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",

--- a/plugins/sam3dj.js
+++ b/plugins/sam3dj.js
@@ -10,7 +10,7 @@
         title: 'sam3DJ',
         author: '1Turtle',
         tags: ['Minecraft: Java Edition', 'Format', 'Exporter'],
-        version: '1.0.4',
+        version: '1.1.0',
         variant: 'both',
         description: 'Generate 3D prints in MC (Java Edition) via the .3DJ format within the SC-Peripherals mod!',
         about: "This plugin allows you to **export a model into the .3DJ format**.  \nThe .3DJ format is _mostly_ used with the `3D Printer` from the **SC-Peripherals** Java Edition mod.  \n  \n**Tip:** Cubes in a `state_on` folder will be _only_ displayed whenever the model is toggled on!    \n> **Note:** _The format does not support the following attributes:_  \n> * Rotated cubes  \n> * One cube with multiple textures  \n> * Cubes outside the given block space *(16x16x16 Grid / 1x1x1 Block)*  \n  \nTry to avoid those things, or else you might run into weird results.  \nMeshes are also not supported due to the limitations of the format and Minecraft.\n> For the full format documentations, see the [SwitchCraft3 Wiki](https://docs.sc3.io/whats-new/sc-peripherals.html#_3dj-format)  \n",

--- a/plugins/sam3dj.js
+++ b/plugins/sam3dj.js
@@ -198,6 +198,7 @@
             output.collideWhenOff   =  options.collideOff;
             output.lightLevel       =  options.lightLvl;
             output.redstoneLevel    =  options.redstoneLvl;
+            if (options.isSeat) output.seatPos = options.seatPos;
         }
         
         const shapes = genModel(Project.elements, options.raw, options.useTint);
@@ -285,6 +286,19 @@
                 type: 'checkbox',
                 value: false,
             },
+            isSeat: {
+                label: 'Is a seat? (OFF = ignore position)',
+                type: 'checkbox',
+                value: false,
+            },
+            seatPos: {
+                label: 'The position of the seat',
+                type: 'vector',
+                value: [0.5,0.5,0.5],
+                min: 0.1,
+                max: 0.9,
+                step: 0.1,
+            }
         },
         onConfirm(formData) {
             codec3dj.export(formData);


### PR DESCRIPTION
The 3dj format has been upgraded to make it possible for players to sit on 3d prints, this PR implements a simple boolean and vector options to make use of those options.

I'm not entirely happy with the vector field's behavior and it's tendency to go bonkers even when the steps are defined to 0.1, but eh, it is what it is.