### PR TITLE
Temporarily deprecate Cube Inverter plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -862,6 +862,7 @@
 		"author": "SirJain",
 		"icon": "swap_horiz",
 		"description": "Adds a button that inverts selected cube sizes.",
+		"tags": ["Deprecated"],
 		"about": "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the toolbar at the top of the screen (the one with the move, resize, and rotation tools) and click the `Invert Cubes` button. If you don't see the button, make sure to select some cubes. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
 		"version": "1.0.0",
 		"min_version": "4.2.0",

--- a/plugins/cube_inverter.js
+++ b/plugins/cube_inverter.js
@@ -19,6 +19,7 @@
                 author,
                 description: "Adds a button that inverts selected cube sizes.",
                 about: "This plugin adds a button that inverts the size values of each selected cube.\n## How to use\nTo use this plugin, go to the toolbar at the top of the screen (the one with the move, resize, and rotation tools) and click the `Invert Cubes` button. If you don't see the button, make sure to select some cubes. The button is also keybinded with a default of `Shift + I`.\n\nPlease report any bugs or suggestions you may have.",
+		tags: ["Deprecated"],
                 version: "1.0.0",
                 min_version: "4.2.0",
                 variant: "both",


### PR DESCRIPTION
The plugin has been broken for a while. I have plans on fixing it at some point when I update some of my plugins to the new system, but I can't do it right now, and I don't want people using it and breaking their projects in the mean time. Will un-deprecate once I look into it.