### PR TITLE
Adds Changelog/Website Link/Contributes data and about.md Updated

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -855,7 +855,12 @@
 		"new_repository_format": true,
 		"await_loading": true,
 		"variant": "both",
-		"creation_date": "2023-04-04"
+		"creation_date": "2023-04-04",
+		"contributes": {
+			"formats": ["azure_model"]
+		},
+		"has_changelog": true,
+		"website": "https://wiki.azuredoom.com/readme-1"
 	},
 	"cube_inverter": {
 		"title": "Cube Inverter",

--- a/plugins/azurelib_utils/about.md
+++ b/plugins/azurelib_utils/about.md
@@ -10,6 +10,7 @@ Supported Minecraft versions:
 - **1.19.4 Forge/Fabric**
 - **1.20.1 Forge/NeoForge/Fabric**
 - **1.20.4 NeoForge/Fabric**
+- **1.20.6 NeoForge/Fabric**
 
 To add to your code, please do the following: 
 
@@ -20,17 +21,21 @@ repositories {
 }
 
 dependencies {
-  //Fabric or Quilt
-  modImplementation "mod.azure.azurelib:azurelib-fabric-MCVER:MODVER"
- 
-  //Forge
-  implementation fg.deobf("mod.azure.azurelib:azurelib-forge-MCVER:MODVER")
- 
-  //NeoForge 1.20.1
-  implementation fg.deobf("mod.azure.azurelib:azurelib-neo-MCVER:MODVER")
+    //Common 1.20.1+ Latest Only
+    compileOnly "mod.azure.azurelib:azurelib-common-MCVERSION:MODVERSION"
   
-  //NeoForge 1.20.4+
-  implementation "mod.azure.azurelib:azurelib-neo-MCVER:MODVER"
+    //Fabric or Quilt and older
+    modImplementation "mod.azure.azurelib:azurelib-fabric-MCVERSION:MODVERSION"
+    modApi "com.terraformersmc:modmenu:VERSION" // Fabric bug is requiring this
+
+    //Forge 1.20.1 and older (Forge is no longer supported)
+    implementation fg.deobf("mod.azure.azurelib:azurelib-forge-MCVERSION:MODVERSION")
+  
+    //NeoForge 1.20.1
+    implementation fg.deobf("mod.azure.azurelib:azurelib-neo-MCVER:MODVER")
+  
+    //NeoForge 1.20.4+
+    implementation "mod.azure.azurelib:azurelib-neo-MCVER:MODVER"
 }
 ```
 <style>

--- a/plugins/azurelib_utils/changelog.json
+++ b/plugins/azurelib_utils/changelog.json
@@ -1,0 +1,24 @@
+{
+	"1.0.6": {
+		"title": "1.0.6",
+		"date": "2024-03-27",
+		"author": "AzureDoom",
+		"categories": [
+			{
+				"title": "Changes",
+				"list": [
+					"Updates about.md for supported versions",
+					"Updates about.md for NeoForge 1.20.4 vs 1.20.1 dependencies",
+					"Adds bvanseg as maintainer for any bug fixes/upcoming rewrites.",
+					"Bumps version to 1.0.6"
+				]
+			},
+			{
+				"title": "Fixes",
+				"list": [
+					"Fixes builtin/entity not being added to display exports."
+				]
+			}
+		]
+	}
+}


### PR DESCRIPTION
Added support for the new changelog feature by adding a changelog based on the example here: https://github.com/JannisX11/blockbench-plugins/blob/master/plugins/minecraft_entity_wizard/changelog.json Please let me know if there an issue with it!

Adds support for the new contributes data in the plugins.json for the `azure_model` model format.

Updated the `about.md` for 1.20.6 support being stated and redid the gradle block to include the common source for multi-loader projects to match how I have it on my wiki. 

Thanks for the awesome new features in the new update!