### PR TITLE
Texture stitcher: fix downloading and update file structure

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -436,7 +436,7 @@
 		"icon": "fa-compress-arrows-alt",
 		"author": "McHorse",
 		"description": "Adds a menu item to textures editor that stitches multiple textures into one",
-		"version": "1.0.4",
+		"version": "1.0.5",
 		"min_version": "4.8.0",
 		"tags": ["Texture"],
 		"variant": "both"

--- a/plugins/texture_stitcher/about.md
+++ b/plugins/texture_stitcher/about.md
@@ -1,0 +1,7 @@
+**Texture stitcher** is a plugin that allows you to take currently imported textures in the **Textures** tab and combine (stitch) them into a single texture.
+
+This is useful when you need to convert/export the textures for specific format that doesn't support multiple textures (Bedrock Model, GeckoLib/AzureLib, BBS mod, etc.).
+
+You can access this feature by right clicking anywhere in the **Textures** tab and clicking **Stitch all textures** option.
+
+**IMPORTANT**: be really careful when you mix **Box UV** with **Per-face** UV modes! It can greatly inflate the size of the texture for the sake of working correctly with **Box UV** elements!

--- a/plugins/texture_stitcher/changelog.json
+++ b/plugins/texture_stitcher/changelog.json
@@ -1,0 +1,29 @@
+{
+	"1.0.4": {
+		"title": "1.0.4",
+		"date": "2024-06-13",
+		"author": "McHorse",
+		"categories": [
+			{
+				"title": "Changes",
+				"list": [
+					"Improved the box packing code to pack boxes much better",
+                    "Implemented proper support for mixed Box UV and Per-face UV modes"
+				]
+			}
+		]
+	},
+	"1.0.5": {
+		"title": "1.0.5",
+		"date": "2024-06-14",
+		"author": "McHorse",
+		"categories": [
+			{
+				"title": "Changes",
+				"list": [
+					"Fixed the plugin not loading correctly due to Blockbench 4.8.0 minimal version"
+				]
+			}
+		]
+	}
+}

--- a/plugins/texture_stitcher/texture_stitcher.js
+++ b/plugins/texture_stitcher/texture_stitcher.js
@@ -12,7 +12,7 @@
         boxes.sort((a, b) => b.h - a.h);
         areas.push(createRect(0, 0, w, Number.MAX_VALUE));
 
-        boxes.forEach(box =>
+        boxes.forEach((box) =>
         {
             for (var i = areas.length - 1; i >= 0; i--)
             {
@@ -322,9 +322,9 @@
     Plugin.register('texture_stitcher', {
         title: 'Texture Stitcher',
         author: 'McHorse',
-        description: 'Adds a menu item to textures editor that stitches multiple textures into one',
+        description: 'Stitch multiple textures into a single texture',
         icon: 'fa-compress-arrows-alt',
-        version: '1.0.4',
+        version: '1.0.5',
         min_version: "4.8.0",
         tags: ["Texture"],
         variant: 'both',


### PR DESCRIPTION
I didn't know if you change minimal version of Blockbench to `4.8.0` you had to change the structure of the plugin as well. This should fix plugin loading from File > Plugins > Available.