### PR TITLE
Texture stitcher: fix UV coordinates broken in Java Block/Item

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -436,7 +436,7 @@
 		"icon": "fa-compress-arrows-alt",
 		"author": "McHorse",
 		"description": "Stitch multiple textures into a single texture",
-		"version": "1.0.5",
+		"version": "1.0.6",
 		"min_version": "4.8.0",
 		"tags": ["Texture"],
 		"variant": "both",

--- a/plugins/texture_stitcher/changelog.json
+++ b/plugins/texture_stitcher/changelog.json
@@ -25,5 +25,18 @@
 				]
 			}
 		]
+	},
+	"1.0.6": {
+		"title": "1.0.6",
+		"date": "2024-06-19",
+		"author": "McHorse",
+		"categories": [
+			{
+				"title": "Changes",
+				"list": [
+					"Fixed UV coordinates broken in Java Block/Item"
+				]
+			}
+		]
 	}
 }

--- a/plugins/texture_stitcher/texture_stitcher.js
+++ b/plugins/texture_stitcher/texture_stitcher.js
@@ -232,6 +232,10 @@
         texture.uv_width = w;
         texture.uv_height = h;
 
+        /* Required to work in Java Block/Item */
+        Project.texture_width = w;
+        Project.texture_height = h;
+
         Cube.all.forEach(cube => 
         {
             var toApplySides = [];
@@ -324,7 +328,7 @@
         icon: 'fa-compress-arrows-alt',
         author: 'McHorse',
         description: 'Stitch multiple textures into a single texture',
-        version: '1.0.5',
+        version: '1.0.6',
         min_version: "4.8.0",
         tags: ["Texture"],
         variant: 'both',


### PR DESCRIPTION
Also, thanks for adding `has_changelog`! 👍 