### PR TITLE
[AWSD Controls] Option to only work when holding RightMouse

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -628,7 +628,7 @@
 	"wasd_controls": {
 		"title": "WASD Controls",
 		"icon": "sports_esports",
-		"author": "JannisX11",
+		"author": "JannisX11, caioraphael1",
 		"description": "Adds a WASD controlled viewport navigation mode",
 		"about": "The WASD mode can be enabled from the View menu.\nThe keys can be remapped in the keybindings menu.\nThe sensitivity can be changed in the settings under Preview, along with the movement plane.\nHold Control to move faster.",
 		"version": "1.2.0",

--- a/plugins.json
+++ b/plugins.json
@@ -631,7 +631,7 @@
 		"author": "JannisX11",
 		"description": "Adds a WASD controlled viewport navigation mode",
 		"about": "The WASD mode can be enabled from the View menu.\nThe keys can be remapped in the keybindings menu.\nThe sensitivity can be changed in the settings under Preview, along with the movement plane.\nHold Control to move faster.",
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"min_version": "4.3.0",
 		"variant": "both"
 	},

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -3,6 +3,7 @@
 let deletables = [];
 
 let old_animate;
+let rightMouseDown = false;
 
 BBPlugin.register('wasd_controls', {
 	title: 'WASD Controls',
@@ -15,41 +16,41 @@ BBPlugin.register('wasd_controls', {
 	variant: 'both',
 	onload() {
 		let navigate_forward = new KeybindItem('navigate_forward', {
-		    name: 'Move Forward',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Forward',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 'w', ctrl: null})
-		})
+		});
 		let navigate_backward = new KeybindItem('navigate_backward', {
-		    name: 'Move Backward',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Backward',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 's', ctrl: null})
-		})
+		});
 		let navigate_left = new KeybindItem('navigate_left', {
-		    name: 'Move Left',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Left',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 'a', ctrl: null})
-		})
+		});
 		let navigate_right = new KeybindItem('navigate_right', {
-		    name: 'Move Right',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Right',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 'd', ctrl: null})
-		})
+		});
 		let navigate_down = new KeybindItem('navigate_down', {
-		    name: 'Move Down',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Down',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 16, ctrl: null})
-		})
+		});
 		let navigate_up = new KeybindItem('navigate_up', {
-		    name: 'Move Up',
-		    icon: 'arrow_upward',
-		    category: 'navigate',
+			name: 'Move Up',
+			icon: 'arrow_upward',
+			category: 'navigate',
 			keybind: new Keybind({key: 32, ctrl: null})
-		})
+		});
 		let navigation_keybinds = [navigate_forward, navigate_backward, navigate_left, navigate_right, navigate_down, navigate_up];
 		deletables.push(...navigation_keybinds);
 
@@ -62,20 +63,26 @@ BBPlugin.register('wasd_controls', {
 		}
 
 		let wasd_toggle = new Toggle('wasd_movement', {
-		    name: 'WASD Movement',
-		    icon: 'sports_esports',
-		    category: 'navigate',
+			name: 'WASD Movement',
+			icon: 'sports_esports',
+			category: 'navigate',
 			value: false,
 			onChange(value) {
 				setupWASDMovement(Preview.selected, value ? 1 : 16);
 				Preview.all.forEach(preview => {
 					preview.controls.enableZoom = !value;
-				})
+				});
 			}
-		})
+		});
+
 		function isWASDMovementEnabled() {
-			return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value;
+			if (settings.requires_hold_right_mouse.value) {
+				return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value && rightMouseDown;
+			} else {
+				return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value
+			}
 		}
+
 		deletables.push(wasd_toggle);
 		MenuBar.menus.view.addAction('_');
 		MenuBar.menus.view.addAction(wasd_toggle);
@@ -86,14 +93,21 @@ BBPlugin.register('wasd_controls', {
 			type: 'number',
 			value: 100,
 			min: 1
-		}))
+		}));
 
 		deletables.push(new Setting('wasd_y_level', {
 			name: 'WASD Navigation at Y Level',
 			description: 'Navigate using WASD at consistent Y level rather than on camera plane',
 			category: 'preview',
 			value: true
-		}))
+		}));
+
+		deletables.push(new Setting('requires_hold_right_mouse', {
+			name: 'Only works when holding the right mouse button',
+			description: 'The WASD Controls neeeds to be enabled for this to work.',
+			category: 'preview',
+			value: true
+		}));
 
 		let pressed_keys = [];
 		Blockbench.on('press_key', data => {
@@ -104,13 +118,25 @@ BBPlugin.register('wasd_controls', {
 					data.capture();
 				}
 			}
-		})
+		});
+
 		document.addEventListener('keyup', event => {
 			pressed_keys.remove(event.which);
-		})
+		});
+
+		document.addEventListener('mousedown', event => {
+			if (event.button === 2) { // Right mouse button
+				rightMouseDown = true;
+			}
+		});
+
+		document.addEventListener('mouseup', event => {
+			if (event.button === 2) { // Right mouse button
+				rightMouseDown = false;
+			}
+		});
 
 		function doWASDMovement() {
-
 			let movement = new THREE.Vector3(0, 0, 0);
 			let uses_wasd_movement = false;
 			function add(x, y, z) {
@@ -149,21 +175,21 @@ BBPlugin.register('wasd_controls', {
 			if (isWASDMovementEnabled() && pressed_keys.length) {
 				doWASDMovement();
 			}
-		}
+		};
 	},
 	oninstall() {
-		MenuBar.menus.view.highlight(BarItems.wasd_movement)
+		MenuBar.menus.view.highlight(BarItems.wasd_movement);
 	},
 	onunload() {
 		deletables.forEach(action => {
 			action.delete();
-		})
+		});
 		setupWASDMovement(Preview.selected, 16);
 		Preview.all.forEach(preview => {
 			preview.controls.enableZoom = true;
-		})
+		});
 		window.animate = old_animate;
 	}
 });
 
-})()
+})();

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -104,7 +104,7 @@ BBPlugin.register('wasd_controls', {
 
 		deletables.push(new Setting('requires_hold_right_mouse', {
 			name: 'Only works when holding the right mouse button',
-			description: 'The WASD Controls neeeds to be enabled for this to work.',
+			description: 'The WASD Controls needs to be enabled for this to work.',
 			category: 'preview',
 			value: true
 		}));

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -76,7 +76,7 @@ BBPlugin.register('wasd_controls', {
 		});
 
 		function isWASDMovementEnabled() {
-			if (settings.requires_hold_right_mouse.value) {
+			if (settings.wasd_requires_hold_right_mouse.value) {
 				return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value && rightMouseDown;
 			} else {
 				return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value
@@ -102,11 +102,11 @@ BBPlugin.register('wasd_controls', {
 			value: true
 		}));
 
-		deletables.push(new Setting('requires_hold_right_mouse', {
+		deletables.push(new Setting('wasd_requires_hold_right_mouse', {
 			name: 'Only works when holding the right mouse button',
 			description: 'The WASD Controls needs to be enabled for this to work.',
 			category: 'preview',
-			value: true
+			value: false
 		}));
 
 		let pressed_keys = [];

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -6,7 +6,7 @@ let rightMouseDown = false;
 BBPlugin.register('wasd_controls', {
 	title: 'WASD Controls',
 	icon: 'sports_esports',
-	author: 'JannisX11',
+	author: 'JannisX11, caioraphael1',
 	description: 'Adds a WASD controlled viewport navigation mode',
 	about: 'The WASD mode can be enabled from the View menu.\nThe keys can be remapped in the keybindings menu.\nThe sensitivity can be changed in the settings under Preview, along with the movement plane.\nHold Control to move faster.',
 	version: '1.2.0',
@@ -54,7 +54,7 @@ BBPlugin.register('wasd_controls', {
 			name: 'Move Faster',
 			icon: 'expand_less',
 			category: 'navigate',
-			keybind: new Keybind({key: 16, ctrl: null})
+			keybind: new Keybind({key: 17, ctrl: null})
 		});
 		let navigate_slower = new KeybindItem('navigate_slower', {
 			name: 'Move Slower',

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -73,16 +73,36 @@ BBPlugin.register('wasd_controls', {
 			preview.controls.target.copy(pos);
 		}
 
+		deletables.push(new Setting('wasd_enabled', {
+			name: 'WASD Controls: Enabled',
+			description: '_',
+			category: 'preview',
+			value: false,
+			onChange(value) {
+				BarItems.wasd_movement.value = value
+				BarItems.wasd_movement.updateEnabledState();
+				setupWASDMovement(Preview.selected, value ? 1 : 16);
+			}
+		}));
+
 		let wasd_toggle = new Toggle('wasd_movement', {
 			name: 'WASD Movement',
 			icon: 'sports_esports',
 			category: 'navigate',
 			value: false,
 			onChange(value) {
+				settings.wasd_enabled.value = value
+				Settings.saveLocalStorages();
 				setupWASDMovement(Preview.selected, value ? 1 : 16);
 			}
 		});
 
+		deletables.push(wasd_toggle);
+		MenuBar.menus.view.addAction('_');
+		MenuBar.menus.view.addAction(wasd_toggle);
+		BarItems.wasd_movement.value = settings.wasd_enabled.value
+		BarItems.wasd_movement.updateEnabledState();
+		
 		function isWASDMovementEnabled() {
 			if (settings.wasd_requires_hold_right_mouse.value) {
 				return Preview.selected && BarItems.wasd_movement && BarItems.wasd_movement.value && rightMouseDown;
@@ -91,12 +111,9 @@ BBPlugin.register('wasd_controls', {
 			}
 		}
 
-		deletables.push(wasd_toggle);
-		MenuBar.menus.view.addAction('_');
-		MenuBar.menus.view.addAction(wasd_toggle);
-
 		deletables.push(new Setting('base_speed', {
 			name: 'WASD Controls: Base Speed',
+			description: '-', 
 			category: 'preview',
 			type: 'number',
 			value: 50,
@@ -105,6 +122,7 @@ BBPlugin.register('wasd_controls', {
 
 		deletables.push(new Setting('move_faster_mult', {
 			name: 'WASD Controls: Move Faster Multiplier',
+			description: '-', 
 			category: 'preview',
 			type: 'number',
 			value: 2,
@@ -114,6 +132,7 @@ BBPlugin.register('wasd_controls', {
 
 		deletables.push(new Setting('move_slower_mult', {
 			name: 'WASD Controls: Move Slower Multiplier',
+			description: '-', 
 			category: 'preview',
 			type: 'number',
 			value: 0.5,
@@ -197,7 +216,6 @@ BBPlugin.register('wasd_controls', {
 					movement.applyEuler(Preview.selected.controls.object.rotation);
 				}
 
-				console.log(movement, Settings.get('base_speed'), speedMultiplier, Settings.get('base_speed') * speedMultiplier / 100)
 				movement.multiplyScalar(Settings.get('base_speed') * speedMultiplier / 100);
 				Preview.selected.camera.position.add(movement);
 				Preview.selected.controls.target.add(movement);

--- a/plugins/wasd_controls.js
+++ b/plugins/wasd_controls.js
@@ -11,7 +11,7 @@ BBPlugin.register('wasd_controls', {
 	author: 'JannisX11',
 	description: 'Adds a WASD controlled viewport navigation mode',
 	about: 'The WASD mode can be enabled from the View menu.\nThe keys can be remapped in the keybindings menu.\nThe sensitivity can be changed in the settings under Preview, along with the movement plane.\nHold Control to move faster.',
-	version: '1.1.0',
+	version: '1.2.0',
 	min_version: '4.3.0',
 	variant: 'both',
 	onload() {


### PR DESCRIPTION
Overall after being edited:
- New option to only enable the controls if the movement is enabled AND is holding the Right Mouse Button.
  - Off by default
  - Disabling the option returns to the old behavior.
- Creation of 2 new buttons: Move Faster and Move Slower, bound to shift and alt by default, with options to change it in the settings.
- The state of the 'WASD Toggle' tool is now saved across restarts.

![image](https://github.com/user-attachments/assets/6cc9328d-5f5f-4a80-af37-4ad05519ab3e)

I really like those new options, as they make the movement more in line with Blender and Godot, for example.