### PR TITLE
[Resource Pack Utilities] Add new utilities

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -363,7 +363,7 @@
 		"author": "Ewan Howell",
 		"description": "A collection of utilities to assist with resource pack creation.",
 		"tags": ["Minecraft: Java Edition", "Resource Packs", "Utilities"],
-		"version": "1.1.0",
+		"version": "1.2.0",
 		"min_version": "4.10.0",
 		"variant": "desktop",
 		"website": "https://ewanhowell.com/plugins/resource-pack-utilities/",

--- a/plugins/resource_pack_utilities/about.md
+++ b/plugins/resource_pack_utilities/about.md
@@ -22,6 +22,10 @@
       <p>CTM Converter is a tool that will convert compact CTM into full CTM or overlay CTM.</p>
     </li>
     <li>
+      <h3>Image Resizer</h3>
+      <p>Image Resizer is a tool that will go through all images in a folder and resize them, relative to their original size.</p>
+    </li>
+    <li>
       <h3>JSON Optimiser</h3>
       <p>JSON Optimiser is a tool that will go through all JSON files in a folder and optimise them to be as small as possible, minifying them and removing any unnecessary data.</p>
     </li>

--- a/plugins/resource_pack_utilities/about.md
+++ b/plugins/resource_pack_utilities/about.md
@@ -10,6 +10,10 @@
       <p>Batch Exporter is a tool that will export every bbmodel file within a folder to an output folder using the selected format.</p>
     </li>
     <li>
+      <h3>Chest Converter</h3>
+      <p>Chest Converter is a tool that will convert the chest textures between the 1.14 format 1.15 format.</p>
+    </li>
+    <li>
       <h3>CIT Optimiser</h3>
       <p>CIT Optimiser is a tool that will go through all properties files in an OptiFine CIT folder and optimise them to be as small as possible, removing any unnecessary data.</p>
     </li>

--- a/plugins/resource_pack_utilities/about.md
+++ b/plugins/resource_pack_utilities/about.md
@@ -14,6 +14,10 @@
       <p>CIT Optimiser is a tool that will go through all properties files in an OptiFine CIT folder and optimise them to be as small as possible, removing any unnecessary data.</p>
     </li>
     <li>
+      <h3>CTM Converter</h3>
+      <p>CTM Converter is a tool that will convert compact CTM into full CTM or overlay CTM.</p>
+    </li>
+    <li>
       <h3>JSON Optimiser</h3>
       <p>JSON Optimiser is a tool that will go through all JSON files in a folder and optimise them to be as small as possible, minifying them and removing any unnecessary data.</p>
     </li>

--- a/plugins/resource_pack_utilities/about.md
+++ b/plugins/resource_pack_utilities/about.md
@@ -18,6 +18,10 @@
       <p>CIT Optimiser is a tool that will go through all properties files in an OptiFine CIT folder and optimise them to be as small as possible, removing any unnecessary data.</p>
     </li>
     <li>
+      <h3>Clock Generator</h3>
+      <p>Clock Generator is a tool that allows you to quickly and easily generate a full set of clock textures from a simple input texture.</p>
+    </li>
+    <li>
       <h3>CTM Converter</h3>
       <p>CTM Converter is a tool that will convert compact CTM into full CTM or overlay CTM.</p>
     </li>

--- a/plugins/resource_pack_utilities/about.md
+++ b/plugins/resource_pack_utilities/about.md
@@ -22,8 +22,16 @@
       <p>Lang Stripper is a tool that will go through all the language files in an resource pack and remove any entries that have not been modified.</p>
     </li>
     <li>
+      <h3>Minecraft Title Converter</h3>
+      <p>Minecraft Title Converter is a tool that will convert images to be in the the Minecraft title format. This can also convert existing textures between the 1.19 and 1.20 texture formats.</p>
+    </li>
+    <li>
       <h3>Missing Textures</h3>
       <p>Missing Textures is a tool that will check what textures you have in a resource pack and tell you which ones the resource pack is missing.</p>
+    </li>
+    <li>
+      <h3>Mojang Converter</h3>
+      <p>Mojang Converter is a tool that will convert images to be in the the Mojang Studios logo format. This can also convert existing textures between the 1.15 and 1.16 texture formats.</p>
     </li>
     <li>
       <h3>Pack Cleaner</h3>
@@ -32,6 +40,14 @@
     <li>
       <h3>Pack Creator</h3>
       <p>Pack Creator is a tool that allows you to create template resource packs, as well as get the vanilla textures, models, sounds, etc…</p>
+    </li>
+    <li>
+      <h3>Skin Converter</h3>
+      <p>Skin Converter is a tool that will convert Minecraft skins between the classic 64x32 format and the modern 64x64 format.</p>
+    </li>
+    <li>
+      <h3>Wide ⇄ Slim Converter</h3>
+      <p>Wide ⇄ Slim Converter is a tool that will convert Minecraft skins between the wide 4px arm format and the slim 3px arm format.</p>
     </li>
   </ul>
 </div>

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -31,5 +31,21 @@
         ]
       }
     ]
+  },
+  "1.2.0": {
+    "title": "1.2.0",
+    "date": "2024-07-19",
+    "author": "Ewan Howell",
+    "categories": [
+      {
+        "title": "New Features",
+        "list": [
+          "Added Minecraft Title Converter utility",
+          "Added Mojang Converter utility",
+          "Added Skin Converter utility",
+          "Added Wide ⇄ Slim Converter utility"
+        ]
+      }
+    ]
   }
 }

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -34,7 +34,7 @@
   },
   "1.2.0": {
     "title": "1.2.0",
-    "date": "2024-07-22",
+    "date": "2024-07-23",
     "author": "Ewan Howell",
     "categories": [
       {
@@ -42,6 +42,7 @@
         "list": [
           "Added Chest Converter utility",
           "Added CTM Converter utility",
+          "Added Image Resizer utility",
           "Added Minecraft Title Converter utility",
           "Added Mojang Converter utility",
           "Added Skin Converter utility",

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -34,13 +34,14 @@
   },
   "1.2.0": {
     "title": "1.2.0",
-    "date": "2024-07-23",
+    "date": "2024-07-24",
     "author": "Ewan Howell",
     "categories": [
       {
         "title": "New Features",
         "list": [
           "Added Chest Converter utility",
+          "Added Clock Generator utility",
           "Added CTM Converter utility",
           "Added Image Resizer utility",
           "Added Minecraft Title Converter utility",

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -34,12 +34,14 @@
   },
   "1.2.0": {
     "title": "1.2.0",
-    "date": "2024-07-21",
+    "date": "2024-07-22",
     "author": "Ewan Howell",
     "categories": [
       {
         "title": "New Features",
         "list": [
+          "Added Chest Converter utility",
+          "Added CTM Converter utility",
           "Added Minecraft Title Converter utility",
           "Added Mojang Converter utility",
           "Added Skin Converter utility",

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -34,7 +34,7 @@
   },
   "1.2.0": {
     "title": "1.2.0",
-    "date": "2024-07-19",
+    "date": "2024-07-21",
     "author": "Ewan Howell",
     "categories": [
       {

--- a/plugins/resource_pack_utilities/resource_pack_utilities.js
+++ b/plugins/resource_pack_utilities/resource_pack_utilities.js
@@ -1032,8 +1032,6 @@
     }
   })
 
-  const clockGeneratorTemplate = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAQBAMAAACigOGCAAAAMFBMVEUAAAD/APv///8AAAAeHBxJaNhsbIl1KAKyZBHclhPpsRX61kr797f99V///wD///9MIKtdAAAABHRSTlMAAAAzDEMHjAAAAMxJREFUeF5tzKEOgkAcgPH/KFoPXwApGtwYuyazMd/AanJmR0GbzUNnVoLJ4mAkguq9go0mI1oJvADe/8YcG3z1t32gATAGoMyq9CoBLOOsDbrRdfza1sEoJOwTSq0bwvwrwSjLAuFICendEfJcQikSMPyYhJDQaUJiqnrfcv4rA6EQEJujREXAJBSGhAedxPTg2FW6LgBXg/SdRmmIMF0gyBAunAfBE2Fp10HbZDzgJ6UJaz9LzzulsdI6ns/YCgGrAbgec6ENwHWhCT8ruX6BrD+klgAAAABJRU5ErkJggg=="
-
   const components = {
     folderSelector: {
       props: {
@@ -4473,15 +4471,16 @@
           gif: null,
           frames: [],
           error: null,
+          template: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAQBAMAAACigOGCAAAAMFBMVEUAAAD/APv///8AAAAeHBxJaNhsbIl1KAKyZBHclhPpsRX61kr797f99V///wD///9MIKtdAAAABHRSTlMAAAAzDEMHjAAAAMxJREFUeF5tzKEOgkAcgPH/KFoPXwApGtwYuyazMd/AanJmR0GbzUNnVoLJ4mAkguq9go0mI1oJvADe/8YcG3z1t32gATAGoMyq9CoBLOOsDbrRdfza1sEoJOwTSq0bwvwrwSjLAuFICendEfJcQikSMPyYhJDQaUJiqnrfcv4rA6EQEJujREXAJBSGhAedxPTg2FW6LgBXg/SdRmmIMF0gyBAunAfBE2Fp10HbZDzgJ6UJaz9LzzulsdI6ns/YCgGrAbgec6ENwHWhCT8ruX6BrD+klgAAAABJRU5ErkJggg=="
         },
         methods: {
-          template() {
+          saveTemplate() {
             Blockbench.export({
               extensions: ["png"],
               type: "PNG",
               name: "template",
               savetype: "image",
-              content: clockGeneratorTemplate
+              content: this.template
             }, () => Blockbench.showQuickMessage("Saved template…"))
           },
           async execute() {
@@ -4544,8 +4543,8 @@
           <div class="row">
             <div class="spacer">The input texture consists of three parts: the clock frame (gets overlayed on top), the rotating dial (should cover the entire area), and a mask to control the dial's visibility (solid pixels show the dial, transparent pixels hide it).</div>
             <div class="col" style="margin-top: -32px;">
-              <img class="checkerboard" width="192" height="64" src="${clockGeneratorTemplate}">
-              <button style="margin-top: -8px;" @click="template">Save template</button>
+              <img class="checkerboard" width="192" height="64" :src="template">
+              <button style="margin-top: -8px;" @click="saveTemplate">Save template</button>
             </div>
           </div>
           <h3>Input texture:</h3>

--- a/plugins/resource_pack_utilities/resource_pack_utilities.js
+++ b/plugins/resource_pack_utilities/resource_pack_utilities.js
@@ -4100,8 +4100,8 @@
           <file-input v-model="files" title="Select your compact CTM" @input="execute" max="5" />
           <h3>Output CTM:</h3>
           <tab-select v-model="mode" :options="modes" @input="execute" />
-          <canvas-output v-if="mode === 'full'" v-model="full" name="full_ctm" :error="error" height="234" />
-          <canvas-output v-if="mode === 'overlay'" v-model="overlay" name="overlay_ctm" :error="error" />
+          <canvas-output v-if="mode === 'full'" v-model="full" name="full_ctm" :error="error" height="192" />
+          <canvas-output v-if="mode === 'overlay'" v-model="overlay" name="overlay_ctm" :error="error" height="192" />
           <button :disabled="!full" @click="save">Export CTM</button>
         `
       }


### PR DESCRIPTION
# Chest Converter
Chest Converter is a tool that will convert the chest textures between the 1.14 format 1.15 format.
# Clock Generator
Clock Generator is a tool that allows you to quickly and easily generate a full set of clock textures from a simple input texture.
# CTM Converter
CTM Converter is a tool that will convert compact CTM into full CTM or overlay CTM.
# Image Resizer
Image Resizer is a tool that will go through all images in a folder and resize them, relative to their original size.
# Minecraft Title Converter
Minecraft Title Converter is a tool that will convert images to be in the the Minecraft title format. This can also convert existing textures between the 1.19 and 1.20 texture formats.
# Mojang Converter
Mojang Converter is a tool that will convert images to be in the the Mojang Studios logo format. This can also convert existing textures between the 1.15 and 1.16 texture formats.
# Skin Converter
Skin Converter is a tool that will convert Minecraft skins between the classic 64x32 format and the modern 64x64 format.
# Wide ⇄ Slim Converter
Wide ⇄ Slim Converter is a tool that will convert Minecraft skins between the wide 4px arm format and the slim 3px arm format.