### PR TITLE
Resource Pack Utilities Plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -365,7 +365,7 @@
 		"author": "Ewan Howell",
 		"description": "A collection of utilities to assist with resource pack creation.",
 		"tags": ["Minecraft: Java Edition", "Resource Packs", "Utilities"],
-		"version": "1.5.0",
+		"version": "1.6.0",
 		"min_version": "4.10.0",
 		"variant": "desktop",
 		"website": "https://ewanhowell.com/plugins/resource-pack-utilities/",

--- a/plugins/resource_pack_utilities/changelog.json
+++ b/plugins/resource_pack_utilities/changelog.json
@@ -117,5 +117,18 @@
         ]
       }
     ]
+  },
+  "1.6.0": {
+    "title": "1.6.0",
+    "date": "2024-09-03",
+    "author": "Ewan Howell",
+    "categories": [
+      {
+        "title": "Bug Fixes",
+        "list": [
+          "Fixed an issue with the Batch Exporter failing to read BBModels in Bedrock format."
+        ]
+      }
+    ]
   }
 }

--- a/plugins/resource_pack_utilities/resource_pack_utilities.js
+++ b/plugins/resource_pack_utilities/resource_pack_utilities.js
@@ -29,7 +29,7 @@
     author: "Ewan Howell",
     description,
     tags: ["Minecraft: Java Edition", "Resource Packs", "Utilities"],
-    version: "1.5.0",
+    version: "1.6.0",
     min_version: "4.10.0",
     variant: "desktop",
     website: `https://ewanhowell.com/plugins/${id.replace(/_/g, "-")}/`,

--- a/plugins/resource_pack_utilities/resource_pack_utilities.js
+++ b/plugins/resource_pack_utilities/resource_pack_utilities.js
@@ -3323,11 +3323,20 @@
               }
               let data
               try {
-                data = JSON.parse(await fs.promises.readFile(path.join(this.inputFolder, file)))
+                data = JSON.parse(await fs.promises.readFile(path.join(this.inputFolder, file)));
               } catch {
-                output.error(`Skipping \`${file}\` as it could not be read`)
-                this.done++
-                continue
+                try {
+                  data = autoParseJSON(
+                    await fs.promises.readFile(
+                      path.join(this.inputFolder, file),
+                      "utf-8"
+                    )
+                  );
+                } catch {
+                  output.error(`Skipping \`${file}\` as it could not be read`);
+                  this.done++;
+                  continue;
+                }
               }
               if (data.meta.model_format !== this.format && !batchExporterSpecialFormats.includes(this.format)) {
                 output.warn(`Skipping \`${file}\` as it is in ${data.meta.model_format in Formats ? `the \`${Formats[data.meta.model_format].name}\`` : "an unknown"} format`)

--- a/plugins/resource_pack_utilities/resource_pack_utilities.js
+++ b/plugins/resource_pack_utilities/resource_pack_utilities.js
@@ -3323,7 +3323,7 @@
               }
               let data
               try {
-                data = JSON.parse(await fs.promises.readFile(path.join(this.inputFolder, file)));
+                data = JSON.parse(await fs.promises.readFile(path.join(this.inputFolder, file)))
               } catch {
                 try {
                   data = autoParseJSON(
@@ -3333,9 +3333,9 @@
                     )
                   );
                 } catch {
-                  output.error(`Skipping \`${file}\` as it could not be read`);
-                  this.done++;
-                  continue;
+                  output.error(`Skipping \`${file}\` as it could not be read`)
+                  this.done++
+                  continue
                 }
               }
               if (data.meta.model_format !== this.format && !batchExporterSpecialFormats.includes(this.format)) {


### PR DESCRIPTION
Fixed bug with the Batch Exporter not being able to read BBModels in bedrock format correctly in the Resource Pack Utilities Plugin, and added a fallback for reading them properly.