### PR TITLE
Animation Utils 3.2

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -400,8 +400,8 @@
 		"tags": [
 			"Minecraft: Java Edition"
 		],
-		"version": "3.1.1",
-		"min_version": "4.8.0",
+		"version": "3.2",
+		"min_version": "4.11.0",
 		"await_loading": true,
 		"variant": "both",
 		"max_version": "5.0.0"

--- a/plugins/animation_utils/CHANGELOG.md
+++ b/plugins/animation_utils/CHANGELOG.md
@@ -6,6 +6,13 @@
 🐞 = Bug Fix<br/>
 🦎 = Non-user-facing Change
 
+## 3.2
+- 🚀 Auto-export the particle texture entry in the textures list for block/item display jsons if not defined
+- 🚀 Auto-convert bedrock animation jsons to GeckoLib-supported animation jsons when exporting
+- 🐞 Fix the particle texture entry not exporting if the name doesn't end in .png
+- 🐞 Fixed item_display_transforms being shipped with .geo jsons for non-bedrock models
+- 🐞 Forced known forward-compatible versions to export as 1.12.0 to maintain compatibility while we work out a better system
+
 ## 3.1.1
 - 🐞 Fix the item display settings being cleared if saving as an entity type model
 - 🐞 Fix the armour template having swapped pivot points on the legs

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -64,6 +64,17 @@ function onBedrockCompile(e: any) {
         })
     }
 
+    // Force-suppress specific version advancement for non-bedrock models to prevent legacy version crashes until a better system is established
+    switch (e.model.format_version) {
+        case "1.14.0":
+        case "1.21.0":
+        case "1.21.20":
+            e.model.format_version = "1.12.0"
+            break;
+        default:
+            break;
+    }
+
     // console.log('onBedrockCompile e:', e);
     // maybeExportItemJson(e.options);
 }

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -2,6 +2,7 @@ import omit from 'lodash/omit';
 import geckoSettings, {GECKO_SETTINGS_DEFAULT, onSettingsChanged} from './settings';
 import {addMonkeypatch, Original} from './utils';
 import type { EasingKey } from './easing';
+import {remove} from "lodash";
 
 interface GeckolibKeyframeOptions extends KeyframeOptions {
   easing: EasingKey
@@ -52,6 +53,17 @@ function onProjectParse(e: any) {
 }
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function onBedrockCompile(e: any) {
+    if (Format.id !== "animated_entity_model") return;
+
+    // Remove display transforms from non-bedrock geometry
+    const geometry = e.model["minecraft:geometry"];
+
+    if (geometry) {
+        geometry.forEach((geo: Map<string, any>) => {
+            delete geo["item_display_transforms"];
+        })
+    }
+
     // console.log('onBedrockCompile e:', e);
     // maybeExportItemJson(e.options);
 }

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -292,10 +292,10 @@ export function maybeExportItemJson(options = {}) {
     }
     if (checkExport('textures', Object.keys(Project.textures).length >= 1)) {
         for (const tex of Project.textures) {
-            if (tex.particle) {
+            if (tex.particle || Object.keys(Project.textures).length === 1) {
                 let name = tex.name;
 
-                if (name.indexOf(".png"))
+                if (name.indexOf(".png") > 0)
                     name = name.substring(0, name.indexOf(".png"))
 
                 const texturesMap = {}

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -2,7 +2,6 @@ import omit from 'lodash/omit';
 import geckoSettings, {GECKO_SETTINGS_DEFAULT, onSettingsChanged} from './settings';
 import {addMonkeypatch, Original} from './utils';
 import type { EasingKey } from './easing';
-import {remove} from "lodash";
 
 interface GeckolibKeyframeOptions extends KeyframeOptions {
   easing: EasingKey

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -88,6 +88,50 @@ function animatorBuildFile() {
                 'geckolib_format_version': geckoSettings.formatVersion,
             }
         );
+
+        // Convert exported bedrock animations to non-bedrock
+        // This should be a menu item but that can be a future thing
+        if (res.animations) {
+            for (const animation in res.animations) {
+                const bones = res.animations[animation].bones;
+
+                if (bones) {
+                    for (const boneName in bones) {
+                        const bone = bones[boneName];
+
+                        for (const animationGroupType in bone) {
+                            const animationGroup = bone[animationGroupType];
+
+                            for (const timestamp in animationGroup) {
+                                const keyframe = animationGroup[timestamp];
+
+                                if (keyframe["lerp_mode"])
+                                    delete keyframe["lerp_mode"];
+
+                                let bedrockKeyframe : Map<any, any> = keyframe["pre"];
+                                let bedrockKeyframeData : Map<any, any> = undefined;
+
+                                if (bedrockKeyframe) {
+                                    bedrockKeyframeData = bedrockKeyframe;
+                                    delete keyframe["pre"]
+                                }
+
+                                bedrockKeyframe = keyframe["post"];
+
+                                if (bedrockKeyframe) {
+                                    bedrockKeyframeData = bedrockKeyframe;
+                                    delete keyframe["post"]
+                                }
+
+                                if (bedrockKeyframeData) {
+                                    Object.assign(keyframe, bedrockKeyframeData)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
     // console.log('animatorBuildFile res:', res);
     return res;

--- a/plugins/animation_utils/src/codec.ts
+++ b/plugins/animation_utils/src/codec.ts
@@ -290,6 +290,22 @@ export function maybeExportItemJson(options = {}) {
             blockmodel.display = new_display
         }
     }
+    if (checkExport('textures', Object.keys(Project.textures).length >= 1)) {
+        for (const tex of Project.textures) {
+            if (tex.particle) {
+                let name = tex.name;
+
+                if (name.indexOf(".png"))
+                    name = name.substring(0, name.indexOf(".png"))
+
+                const texturesMap = {}
+                texturesMap['particle'] = name
+                blockmodel.textures = texturesMap;
+
+                break
+            }
+        }
+    }
 
     const blockmodelString = JSON.stringify(blockmodel, null, 2);
 
@@ -326,6 +342,7 @@ const format = new ModelFormat({
     bone_rig: true,
     centered_grid: true,
     animated_textures: true,
+    select_texture_for_particles: true,
     animation_mode: true,
     animation_files: true,
     locators: true,

--- a/plugins/animation_utils/src/package-lock.json
+++ b/plugins/animation_utils/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "animation_utils",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "animation_utils",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.21",

--- a/plugins/animation_utils/src/package.json
+++ b/plugins/animation_utils/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animation_utils",
-  "version": "3.1.1",
+  "version": "3.2",
   "private": true,
   "description": "GeckoLib",
   "main": "index.js",
@@ -24,7 +24,7 @@
     "author": "Eliot Lash, Gecko, McHorse, AzureDoom, Tslat",
     "icon": "icon.png",
     "description": "Create animated blocks, items, entities, and armor using the GeckoLib library and plugin.",
-    "min_version": "4.8.0",
+    "min_version": "4.11.0",
     "max_version": "5.0.0",
     "variant": "both"
   },


### PR DESCRIPTION
3.2
- 🚀 Auto-export the particle texture entry in the textures list for block/item display jsons if not defined
- 🚀 Auto-convert bedrock animation jsons to GeckoLib-supported animation jsons when exporting
- 🐞 Fix the particle texture entry not exporting if the name doesn't end in .png
- 🐞 Fixed item_display_transforms being shipped with .geo jsons for non-bedrock models
- 🐞 Forced known forward-compatible versions to export as 1.12.0 to maintain compatibility while we work out a better system