### PR TITLE
Update Double Sided Cubes to v1.1.0

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -63,7 +63,7 @@
 		"icon": "flip_to_back",
 		"description": "Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in Minecraft: Java Edition.",
 		"tags": ["Minecraft: Java Edition"],
-		"version": "1.0.1",
+		"version": "1.1.0",
 		"variant": "both"
 	},
 	"optimize": {

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -1,53 +1,58 @@
-(()=> {
+;(() => {
+	let cube_action
 
-	let cube_action;
-
-	Plugin.register('double_sided_cubes', {
+	BBPlugin.register('double_sided_cubes', {
 		title: 'Double Sided Cubes',
 		author: 'SnaveSutit',
-		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
-        tags: ["Minecraft: Java Edition"],
+		description:
+			'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
 		icon: 'flip_to_back',
-		version: '1.0.1',
+		version: '1.1.0',
 		variant: 'both',
 		onload() {
 			cube_action = new Action({
-				id:"create_double_sided_cubes",
+				id: 'create_double_sided_cubes',
 				name: 'Create Double Sided Cube',
 				icon: 'flip_to_back',
 				category: 'edit',
-				condition: () => !Project.box_uv,
-				click: function(ev) {
-					if (selected.length === 0) {
-						Blockbench.showMessage('No cubes selected', 'center')
-						return;
-					};
-					Undo.initEdit({elements:[]});
-					let cubes = [];
-					Cube.selected.forEach((cube) => {
-						const new_cube = cube.duplicate();
-						new_cube.name = new_cube.name + " inverted";
-						if (cube.parent !== "root") {
-							new_cube.addTo(cube.parent);
-						};
-						for (i=0; i<3; i++){
+				click() {
+					if (Project.box_uv) {
+						Blockbench.showQuickMessage(
+							'Cannot make double sided cubes with BoxUV enabled!',
+							2000
+						)
+						return
+					}
+					if (Cube.selected === 0) {
+						Blockbench.showQuickMessage('No Cubes Selected!', 2000)
+						return
+					}
+					Undo.initEdit({ elements: [] })
+					let cubes = []
+					Cube.selected.forEach(cube => {
+						const new_cube = new Cube({ ...cube }).init()
+						new_cube.box_uv = false
+						new_cube.name = new_cube.name + '_inverted'
+						if (cube.parent !== 'root') {
+							new_cube.addTo(cube.parent, cube.parent.children.indexOf(cube) + 1)
+						}
+						for (i = 0; i < 3; i++) {
 							new_cube.flip(i, 0, false)
-						};
-						new_cube.from = [...cube.to];
-						new_cube.to = [...cube.from];
-						new_cube.inflate = -new_cube.inflate;
-						new_cube.origin = [-new_cube.origin[0],-new_cube.origin[1],-new_cube.origin[2]];
-						Canvas.adaptObjectPosition(new_cube);
-						Canvas.updateUV(new_cube);
-						cubes.push(new_cube);
-					});
-					Undo.finishEdit('create_double_sided_cube', {elements:cubes});
-				}
-			});
-			MenuBar.addAction(cube_action, 'filter');
+						}
+						new_cube.from = [...cube.to]
+						new_cube.to = [...cube.from]
+						new_cube.inflate = -new_cube.inflate
+						Canvas.adaptObjectPosition(new_cube)
+						Canvas.updateUV(new_cube)
+						cubes.push(new_cube)
+					})
+					Undo.finishEdit('create_double_sided_cube', { elements: cubes })
+				},
+			})
+			MenuBar.addAction(cube_action, 'filter')
 		},
 		onunload() {
-			cube_action.delete();
-		}
-	});
-})();
+			cube_action.delete()
+		},
+	})
+})()


### PR DESCRIPTION
- Removed invisible conditions.
- Cancel inversion if the project has BoxUV enabled, and tell the user why.
- Automatically disable BoxUV on inverted cubes if project UV mode isn't defaulted to BoxUV.
- Use `Cube.selected` instead of `selected` to loop through selected cubes.
- Formatted with prettier.