### PR TITLE
BBS exporter: Use applied texture's size for UVs

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -798,7 +798,7 @@
 		"icon": "icon.png",
 		"author": "McHorse",
 		"description": "Adds actions to export/import models in BBS format, which is used by BBS machinima studio.",
-		"version": "1.2.3",
+		"version": "1.2.4",
 		"variant": "both",
 		"tags": ["Exporter", "Importer"],
 		"min_version": "4.8.0",

--- a/plugins/bbs_exporter/bbs_exporter.js
+++ b/plugins/bbs_exporter/bbs_exporter.js
@@ -300,6 +300,39 @@
 
     function compile()
     {
+        function findTextureSize()
+        {
+            var c = Cube.all;
+            var keys = Object.keys(sides);
+
+            for (var i = 0; i < c.length; i++)
+            {
+                var cube = c[i];
+
+                for (var j = 0; j < keys.length; j++)
+                {
+                    var face = cube.faces[keys[j]];
+
+                    if (face)
+                    {
+                        var textureUuid = face.texture;
+
+                        for (var k = 0; k < Texture.all.length; k++)
+                        {
+                            var texture = Texture.all[k];
+
+                            if (texture && texture.uuid == textureUuid)
+                            {
+                                return [texture.width, texture.height];
+                            }
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
         var output = {
             version: "0.7.2",
             animations: {}
@@ -307,9 +340,17 @@
 
         if (lastOptions.model)
         {
+            var texture = [Project.texture_width, Project.texture_height];
+            var textureSize = findTextureSize();
+
+            if (textureSize)
+            {
+                texture = textureSize;
+            }
+
             output.model = {
                 groups: createHierarchy(Outliner.root),
-                texture: [Project.texture_width, Project.texture_height]
+                texture: texture
             };
         }
 
@@ -609,7 +650,7 @@
         author: "McHorse",
         description: "Adds actions to export/import models in BBS format, which is used by BBS machinima studio.",
         icon: "icon.png",
-        version: "1.2.3",
+        version: "1.2.4",
         min_version: "4.8.0",
         variant: "both",
         has_changelog: true,

--- a/plugins/bbs_exporter/changelog.json
+++ b/plugins/bbs_exporter/changelog.json
@@ -24,5 +24,18 @@
 				]
 			}
 		]
+	},
+	"1.2.4": {
+		"title": "1.2.4",
+		"date": "2024-12-11",
+		"author": "McHorse",
+		"categories": [
+			{
+				"title": "Bug fixes",
+				"list": [
+					"When exporting the model's UV is incorrectly picked from the project's texture size rather than from the active texture"
+				]
+			}
+		]
 	}
 }


### PR DESCRIPTION
My users have noticed that models were exported with the plugin with incorrect texture width and height. The problem was inconsistency with File > Project > Texture size and texture's actual size.