### PR TITLE
Fix "Group Exporter" not available in Blockbench

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1067,5 +1067,20 @@
 		"has_changelog": true,
 		"min_version": "4.10.4",
 		"repository": "https://github.com/Shadowkitten47/Meshy"
+	},
+	"outliner_group_exporter": {
+		"title": "Group Exporter",
+		"author": "MrCrayfish",
+		"creation_date": "2025-03-19",
+		"icon": "icon.png",
+		"description": "A simple plugin to allow you to export a group from the outliner as a model. Only cubes inside the group will be exported.",
+		"variant": "both",
+		"version": "1.0.0",
+		"tags": [
+			"Minecraft: Java Edition"
+		],
+		"has_changelog": true,
+		"min_version": "4.10.1",
+		"repository": "https://github.com/JannisX11/blockbench-plugins/tree/master/plugins/outliner_group_exporter"
 	}
 }

--- a/plugins/outliner_group_exporter/changelog.json
+++ b/plugins/outliner_group_exporter/changelog.json
@@ -1,0 +1,15 @@
+{
+    "1.0.0": {
+        "title": "1.0.0",
+        "date": "2025-03-19",
+        "author": "MrCrayfish",
+        "categories": [
+            {
+                "title": "Features",
+                "list": [
+                    "Initial release"
+                ]
+            }
+        ]
+    }
+}

--- a/plugins/outliner_group_exporter/outliner_group_exporter.js
+++ b/plugins/outliner_group_exporter/outliner_group_exporter.js
@@ -8,7 +8,7 @@
         icon: 'icon.png',
         description: 'A simple plugin to allow you to export a group from the outliner as a model. Only cubes inside the group will be exported.',
         tags: ['Minecraft Java Edition'],
-        version: '0.0.1',
+        version: '1.0.0',
         min_version: '4.10.1',
         variant: 'both',
         onload() {


### PR DESCRIPTION
I forgot to publish my "Group Exporter" plugin into the `plugins.json` file. Should now be ready to go
