### PR TITLE
Ignoring if format is java_block on the Simplify plugin when simplifying rotation.

### DIFF
--- a/plugins/simplify.js
+++ b/plugins/simplify.js
@@ -55,7 +55,9 @@ Plugin.register("simplify", {
 							cubes[i].faces.west.uv = Simplify(cubes[i].faces.west.uv, data.roundAmount);
 
 							// rotation
-							cubes[i].rotation = Simplify(cubes[i].rotation, data.roundAmount);
+							if (Project.format.id != "java_block") {
+								cubes[i].rotation = Simplify(cubes[i].rotation, data.roundAmount);
+							}
 
 							// origin
 							cubes[i].origin = Simplify(cubes[i].origin, data.roundAmount);


### PR DESCRIPTION
This would make the models not load at all in Minecraft.