### PR TITLE
Fix typo in README regarding plugin curation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ In order to submit your plugin, you need to meet a few requirements:
 * Plugins should not be larger than 2 MB
 * Make sure to not bundle dependencies that are already included in Blockbench. Blockbench comes with a number of libraries already included that can be used by plugins, such as ThreeJS, Vue 2, JSZip, Marked, and MolangJS.
 * Plugins may not execute code from external sources. This includes separately hosted scripts, user inputs or files, or otherwise externally hosted or generated code. This also applies to rendering of HTML content.
-* This list of plugins is curated to some extend. Plugins will be reviewed and may not be accepted if they don't meet quality standards. Already published plugins may also be taken down if they no longer meet the requirements.
+* This list of plugins is curated to some extent. Plugins will be reviewed and may not be accepted if they don't meet quality standards. Already published plugins may also be taken down if they no longer meet the requirements.
 * While it is the goal to keep the plugin API generally compatible across different Blockbench version, it can happen that a feature is changed or deprecated and your plugin must be updated in order to keep working.
 
 Once you are ready to submit your plugin, create a pull request.


### PR DESCRIPTION
This pull request makes a minor correction to the documentation by fixing a typo in the requirements list for submitting plugins. No functional or code changes are included.

* Fixed a typo in the `README.md` requirements section, changing "to some extend" to "to some extent"