### PR TITLE
[glTF Importer] Better handling of double sided faces

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1211,7 +1211,7 @@
 		"description": "Import .GLTF and .GLB models",
 		"icon": "icon.png",
 		"creation_date": "2025-09-25",
-		"version": "1.0.0",
+		"version": "1.1.0",
 		"variant": "desktop",
 		"min_version": "4.12.6",
 		"has_changelog": false,

--- a/plugins/gltf_importer/src/README.md
+++ b/plugins/gltf_importer/src/README.md
@@ -1,4 +1,4 @@
-# Joint Pain
+# glTF Importer
 
 A plugin to import glTF models into Blockbench.
 The approach is to use THREE.js GLTFLoader to import the glTF into

--- a/plugins/gltf_importer/src/plugin/plugin.ts
+++ b/plugins/gltf_importer/src/plugin/plugin.ts
@@ -10,7 +10,7 @@ BBPlugin.register('gltf_importer', {
     description:   'Import .GLTF and .GLB models',
     icon:          'icon.png',
     creation_date: '2025-09-25',
-    version:       '1.0.0',
+    version:       '1.1.0',
     variant:       'desktop',
     min_version:   '4.12.6',
     has_changelog: false,   
@@ -44,7 +44,6 @@ BBPlugin.register('gltf_importer', {
         type ImportGltfFormResult = {
             file?: Filesystem.FileResult,
             scale: number,
-            backFaces: boolean,
             groups: boolean,
             cameras: boolean,
             animations: boolean,
@@ -67,11 +66,6 @@ BBPlugin.register('gltf_importer', {
                     type: 'number',
                     label: 'Scale',
                     value: Settings.get('model_export_scale'),
-                },
-                ['backFaces']: {
-                    type: 'checkbox',
-                    label: 'Double-sided faces',
-                    value: false,
                 },
                 ['groups']: {
                     type: 'checkbox',
@@ -108,7 +102,6 @@ BBPlugin.register('gltf_importer', {
                 let importOptions: ImportOptions = {
                     file: formOptions.file!,
                     scale: formOptions.scale,
-                    backFaces: formOptions.backFaces,
                     groups: formOptions.groups,
                     cameras: formOptions.cameras,
                     animations: formOptions.animations,


### PR DESCRIPTION
Improvement in how double sided faces are handled.
Before, the import dialog had a 'Double sided faces' checkbox, which when enabled would just duplicate all faces.
With this change it actually looks at the imported materials to see if a texture should be double sided, and uses the standard Blockbench double sided faces property instead of duplicating them.

Version bump to 1.1.0