### PR TITLE
🩹 Allow AJ to be installed on 5.0.0 and above

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -19,8 +19,7 @@
 		"variant": "desktop",
 		"tags": ["Minecraft: Java Edition", "Animation", "Display Entities"],
 		"min_version": "4.12.0",
-		"has_changelog": true,
-		"max_version": "4.12.6"
+		"has_changelog": true
 	},
 	"animated_platforms": {
 		"title": "Animated Platforms",


### PR DESCRIPTION
Removes `max_version` from AJ's plugin definition.

Animated Java has a built-in catch for being installed on Blockbench 5+ that cancels instantiation, and pops up the following message:
<img width="707" height="553" alt="image" src="https://github.com/user-attachments/assets/1e553685-469d-436f-bdac-377871fbed64" />

The code for the catch is right at the top of the file in the current release (1.8.1) of AJ:
<img width="1403" height="460" alt="image" src="https://github.com/user-attachments/assets/13494c28-a1b9-40e0-8b5a-a69f35b53158" />

This will *hopefully* be a more obvious way to get the news out to any confused users, and save my discord channels from the hundreds of messages asking why AJ doesn't work in the latest version of Blockbench, even though they could scroll up 5 messages in the general chat and get their answer, or read the pinned announcement 😅...