### PR TITLE
Add voxelizer plugin

### DIFF
--- a/plugins/voxelizer/voxelizer-plugin.js
+++ b/plugins/voxelizer/voxelizer-plugin.js
@@ -1,0 +1,15 @@
+(function() {
+    Plugin.register('voxelizer', {
+        title: 'Voxelizer',
+        author: 'PAT1519',
+        icon: 'icon.png',
+        description: 'Converts Mesh geometry into standard Java Cubes while preserving original position, size, and rotation.',
+        version: '1.0.0',
+        min_version: '4.8.0',
+        variant: 'both',
+        onload() {
+        },
+        onunload() {
+        }
+    });
+})();


### PR DESCRIPTION
This plugin converts Mesh geometry into standard Java Cubes while preserving the original position, size, and rotation.

> **_IMPORTANT:_**  Please remember to update plugin metadata in plugins.json along with the metadata in your plugin. Always increase the version number when submitting an update.

Please only update one plugin per pull-request (unless you are applying the same fix to multiple pull requests, and nothing else).
