### PR TITLE
Double Sided Cubes: Add support for Optional Box UV + misc bug fixes

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -92,7 +92,7 @@
 		"variant": "both"
 	},
 	"double_sided_cubes": {
-		"title": "Double Sided Cube Generator",
+		"title": "Double Sided Cubes",
 		"author": "SnaveSutit",
 		"icon": "flip_to_back",
 		"description": "Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in Minecraft: Java Edition.",

--- a/plugins.json
+++ b/plugins.json
@@ -97,7 +97,7 @@
 		"icon": "flip_to_back",
 		"description": "Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in Minecraft: Java Edition.",
 		"tags": ["Minecraft: Java Edition"],
-		"version": "1.0.1",
+		"version": "1.0.2",
 		"variant": "both"
 	},
 	"optimize": {

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -5,7 +5,7 @@
 	Plugin.register('double_sided_cubes', {
 		title: 'Double Sided Cubes',
 		author: 'SnaveSutit',
-		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
+		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in Minecraft: Java Edition.',
         tags: ["Minecraft: Java Edition"],
 		icon: 'flip_to_back',
 		version: '1.0.2',

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -30,14 +30,15 @@
 						if (!!new_cube.box_uv) {
 							new_cube.setUVMode(false);
 						}
-						// cube.duplicate() will sometimes change the name of the duplicated cube, 
-						//   so we base this on cube.name instead of new_cube.name.
-						new_cube.name = cube.name + " inverted";
-						// Place new_cube immediately after cube in the outliner
-						new_cube.sortInBefore(cube, 1);
+						// Invert new_cube
 						for (i=0; i<3; i++){
 							new_cube.flip(i, 0, false)
 						};
+						// cube.duplicate() and new_cube.flip(...) will sometimes change new_cube.name, 
+						//   so we make sure to set the name here, and base it on cube.name instead
+						new_cube.name = cube.name + " inverted";
+						// Place new_cube immediately after cube in the outliner
+						new_cube.sortInBefore(cube, 1);
 						new_cube.from = [...cube.to];
 						new_cube.to = [...cube.from];
 						new_cube.inflate = -new_cube.inflate;

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -12,11 +12,11 @@
 		variant: 'both',
 		onload() {
 			cube_action = new Action({
-				id:"create_double_sided_cubes",
+				id: "create_double_sided_cubes",
 				name: 'Create Double Sided Cube',
 				icon: 'flip_to_back',
 				category: 'edit',
-				condition: () => !Project.box_uv,
+				condition: () => !Project.box_uv || Project.optional_box_uv,
 				click: function(ev) {
 					if (selected.length === 0) {
 						Blockbench.showMessage('No cubes selected', 'center')
@@ -26,10 +26,15 @@
 					let cubes = [];
 					Cube.selected.forEach((cube) => {
 						const new_cube = cube.duplicate();
-						new_cube.name = new_cube.name + " inverted";
-						if (cube.parent !== "root") {
-							new_cube.addTo(cube.parent);
-						};
+						// Set the new cube to Per-Face UV if it was using Box UV
+						if (!!new_cube.box_uv) {
+							new_cube.setUVMode(false);
+						}
+						// cube.duplicate() will sometimes change the name of the duplicated cube, 
+						//   so we base this on cube.name instead of new_cube.name.
+						new_cube.name = cube.name + " inverted";
+						// Place new_cube immediately after cube in the outliner
+						new_cube.sortInBefore(cube, 1);
 						for (i=0; i<3; i++){
 							new_cube.flip(i, 0, false)
 						};

--- a/plugins/double_sided_cubes.js
+++ b/plugins/double_sided_cubes.js
@@ -8,7 +8,7 @@
 		description: 'Creates inverted duplicates of the selected cube(s) to allow double-sided rendering in java edition.',
         tags: ["Minecraft: Java Edition"],
 		icon: 'flip_to_back',
-		version: '1.0.1',
+		version: '1.0.2',
 		variant: 'both',
 		onload() {
 			cube_action = new Action({


### PR DESCRIPTION
**Plugin:** Double Sided Cubes

**Problems:**
1. Double Sided Cubes is not available when Box UVs are the default, even if Per-Face UVs are available and in use.
2. Inverted cubes will use invalid Box UVs if the original cube was using Box UVs.
3. Inverted cubes will sometimes be incorrectly named (e.g. inverting "cube1" will create a cube named "cube2 inverted" instead of "cube1 inverted").
4. Double Sided Cubes has legacy plugin metadata that fails to validate.

**Solutions:**
1. Allowed Double Sided Cubes to run when optional Box UVs are supported by the format
3. Inverted cubes are automatically switched to Per-Face UVs if the original cube was using Box UVs
4. Base the inverted cube's name on the original `cube.name`, instead of the name given by `cube.duplicate()`
5. Updated plugin metadata to be valid.

**Additional Changes:**
* Now places inverted cubes immediately after the original cubes in the outliner, instead of at the bottom of the group.