### PR TITLE
[Minecraft Title Generator] Fix 1.2.2 and 1.3.0 changelog entries

### DIFF
--- a/plugins/minecraft_title_generator/changelog.json
+++ b/plugins/minecraft_title_generator/changelog.json
@@ -170,6 +170,25 @@
       }
     ]
   },
+  "1.2.2": {
+    "title": "1.2.2",
+    "date": "2023-09-21",
+    "author": "Ewan Howell",
+    "categories": [
+      {
+        "title": "Technical Changes",
+        "list": [
+          "Added CDN url fallback system, so the fonts and textures now try each source in turn instead of failing on the first"
+        ]
+      },
+      {
+        "title": "Bug Fixes",
+        "list": [
+          "Fixed a font list layout issue"
+        ]
+      }
+    ]
+  },
   "1.3.0": {
     "title": "1.3.0",
     "date": "2023-09-23",
@@ -184,7 +203,6 @@
       {
         "title": "Technical Changes",
         "list": [
-          "Added CDN url fallback system",
           "Font variants are a breaking change so the sources have been moved to a temporary dev branch"
         ]
       }


### PR DESCRIPTION
Backfills the missing 1.2.2 entry, and moves the CDN url fallback system onto it. 1.2.2 is the version that actually added it; 1.3.0 only used it for the new font variant thumbnails.
