### PR TITLE
[OptiFine Player Models] v1.5.2

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -259,18 +259,22 @@
 	},
 	"optifine_player_models": {
 		"title": "OptiFine Player Models",
-		"icon": "icon-player",
+		"icon": "icon.png",
 		"author": "Ewan Howell",
 		"description": "Adds a new format that allows you to create OptiFine player models.",
 		"tags": ["Minecraft: Java Edition", "OptiFine", "Player Models"],
-		"version": "1.5.0",
+		"version": "1.5.2",
 		"min_version": "5.0.0",
 		"variant": "both",
 		"await_loading": true,
 		"creation_date": "2022-05-29",
 		"contributes": {
 			"formats": ["optifine_player_model"]
-		}
+		},
+		"website": "https://ewanhowell.com/plugins/optifine-player-models/",
+		"repository": "https://github.com/ewanhowell5195/blockbenchPlugins/tree/main/optifine_player_models",
+		"bug_tracker": "https://github.com/ewanhowell5195/blockbenchPlugins/issues?title=[OptiFine Player Models]",
+		"has_changelog": true
 	},
 	"colour_gradient_generator": {
 		"title": "Colour Gradient Generator",

--- a/plugins/optifine_player_models/changelog.json
+++ b/plugins/optifine_player_models/changelog.json
@@ -147,5 +147,19 @@
         ]
       }
     ]
+  },
+  "1.5.2": {
+    "title": "1.5.2",
+    "date": "2026-08-23",
+    "author": "Ewan Howell",
+    "categories": [
+      {
+        "title": "Technical Changes",
+        "list": [
+          "Fixed outdated plugin metadata that stopped 1.5.1 from releasing",
+          "The changelog, links, and icon are now shown correctly in the plugin browser"
+        ]
+      }
+    ]
   }
 }

--- a/plugins/optifine_player_models/optifine_player_models.js
+++ b/plugins/optifine_player_models/optifine_player_models.js
@@ -57,7 +57,7 @@
     author: "Ewan Howell",
     description,
     tags: ["Minecraft: Java Edition", "OptiFine", "Player Models"],
-    version: "1.5.1",
+    version: "1.5.2",
     min_version: "5.0.0",
     variant: "both",
     await_loading: true,


### PR DESCRIPTION
The `plugins.json` entry had drifted from the plugin file, so 1.5.1 never actually released and the changelog was never shown.

## Technical Changes
- Fixed outdated plugin metadata that stopped 1.5.1 from releasing
- The changelog, links, and icon are now shown correctly in the plugin browser
